### PR TITLE
2024.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,23 @@ instance.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://m
 
 The interface will show a form to fill in with the following information:
 
-| Name                                    | Description                                                                                             | Required |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------- |
-| Infrared ID                             | IR HUB Device ID (retrieved from Tuya Platform).                                                        | Yes      |
-| Climate ID                              | Air Conditioner Device ID (retrieved from Tuya Platform).                                               | Yes      |
-| Air conditioner name                    | Name of the device that will be displayed in Home Assistant.                                            | Yes      |
-| Temperature sensor                      | Name of the temperature sensor to pair with the device.                                                 | No       |
-| Humidity sensor                         | Name of the humidity sensor to pair with the device.                                                    | No       |
-| Minimum temperature                     | Minimum set point availabl supported by the device.                                                     | No       |
-| Maximum temperature                     | Maximum set point available supported by the device.                                                    | No       |
-| Step temperature                        | Step size for temperature set point supported by the device.                                            | No       |
-| HVAC modes supported                    | HVAC modes supported by the device.                                                                     | No       |
-| FAN modes supported                     | FAN modes supported by the device.                                                                      | No       |
-| *Force power on when setting hvac mode* | *Send a double power command when setting an HVAC mode (fixes compatibility issues with some devices).* | No       |
-| *Set minimum temperature in dry mode*   | *Set temperature to 16° when DRY MODE is selected (fixes compatibility issues with some devices).*      | No       |
-| *Set minimum fan mode in dry mode*      | *Set fan speed to LOW when DRY MODE is selected (fixes compatibility issues with some devices).*        | No       |
+| Name                                        | Description                                                                                             |
+| ---------------------------------------     | ------------------------------------------------------------------------------------------------------- |
+| Infrared ID                                 | IR HUB Device ID (retrieved from Tuya Platform).                                                        |
+| Climate ID                                  | Air Conditioner Device ID (retrieved from Tuya Platform).                                               |
+| Air conditioner name                        | Name of the device that will be displayed in Home Assistant.                                            |
+| Temperature sensor                          | Name of the temperature sensor to pair with the device.                                                 |
+| Humidity sensor                             | Name of the humidity sensor to pair with the device.                                                    |
+| Minimum temperature                         | Minimum set point availabl supported by the device.                                                     |
+| Maximum temperature                         | Maximum set point available supported by the device.                                                    |
+| Step temperature                            | Step size for temperature set point supported by the device.                                            |
+| HVAC modes supported                        | HVAC modes supported by the device.                                                                     |
+| FAN modes supported                         | FAN modes supported by the device.                                                                      |
+| Default temperatures when setting HVAC mode | Enable default temperature settings when changing HVAC modes to auto, cool and heat.                    |
+| Default fan speed when setting HVAC mode    | Enable default fan speed settings when changing HVAC modes.                                             |
+| *Force power on when setting hvac mode*     | *Send a double power command when setting an HVAC mode (fixes compatibility issues with some devices).* |
+| *Set minimum temperature in dry mode*       | *Set temperature to 16° when DRY MODE is selected (fixes compatibility issues with some devices).*      |
+| *Set minimum fan mode in dry mode*          | *Set fan speed to LOW when DRY MODE is selected (fixes compatibility issues with some devices).*        |
 
 # Debug
 It is possible to activate debug mode by adding the following lines in your configuration.yaml file:

--- a/custom_components/tuya_smart_ir_ac/api.py
+++ b/custom_components/tuya_smart_ir_ac/api.py
@@ -68,6 +68,6 @@ class TuyaDetails(object):
         self.url = url
         self.request = request
         self.response = response
-        
+
     def to_dict(self):
         return vars(self)

--- a/custom_components/tuya_smart_ir_ac/climate.py
+++ b/custom_components/tuya_smart_ir_ac/climate.py
@@ -1,75 +1,35 @@
 import logging
 from homeassistant.core import callback
+from homeassistant.helpers import entity_registry
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     FAN_AUTO,
-    FAN_LOW,
     HVACMode,
     ClimateEntityFeature
 )
-from homeassistant.const import (
-    UnitOfTemperature, 
-    STATE_UNKNOWN, 
-    STATE_UNAVAILABLE,
-    CONF_NAME
-)
+from homeassistant.const import UnitOfTemperature
 from .const import (
     DOMAIN,
-    MANUFACTURER,
-    COORDINATOR,
-    CONF_INFRARED_ID,
-    CONF_CLIMATE_ID,
-    CONF_TEMPERATURE_SENSOR,
-    CONF_HUMIDITY_SENSOR,
-    CONF_TEMP_MIN,
-    CONF_TEMP_MAX,
-    CONF_TEMP_STEP,
-    CONF_HVAC_MODES,
-    CONF_FAN_MODES,
-    CONF_HVAC_POWER_ON,
-    CONF_DRY_MIN_TEMP,
-    CONF_DRY_MIN_FAN,
-    DEFAULT_MIN_TEMP,
-    DEFAULT_MAX_TEMP,
-    DEFAULT_PRECISION,
-    DEFAULT_HVAC_MODES,
-    DEFAULT_FAN_MODES,
-    DEFAULT_HVAC_POWER_ON,
-    DEFAULT_DRY_MIN_TEMP,
-    DEFAULT_DRY_MIN_FAN
+    COORDINATOR
 )
+from .helpers import valid_sensor_state
+from .entity import TuyaEntity
 
 _LOGGER = logging.getLogger(__package__)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     coordinator = hass.data.get(DOMAIN).get(COORDINATOR)
-    async_add_entities([TuyaClimate(hass, config_entry.data, coordinator)])
+    registry = entity_registry.async_get(hass)
+    async_add_entities([TuyaClimate(config_entry.data, coordinator, registry)])
 
 
-class TuyaClimate(ClimateEntity, RestoreEntity, CoordinatorEntity):
-    def __init__(self, hass, config, coordinator):
-        self._infrared_id = config.get(CONF_INFRARED_ID)
-        self._climate_id = config.get(CONF_CLIMATE_ID)
-        self._name = config.get(CONF_NAME)
-        self._temperature_sensor = config.get(CONF_TEMPERATURE_SENSOR, None)
-        self._humidity_sensor = config.get(CONF_HUMIDITY_SENSOR, None)
-        self._min_temp = config.get(CONF_TEMP_MIN, DEFAULT_MIN_TEMP)
-        self._max_temp = config.get(CONF_TEMP_MAX, DEFAULT_MAX_TEMP)
-        self._temp_step = config.get(CONF_TEMP_STEP, DEFAULT_PRECISION)
-        self._hvac_modes = config.get(CONF_HVAC_MODES, DEFAULT_HVAC_MODES)
-        self._fan_modes = config.get(CONF_FAN_MODES, DEFAULT_FAN_MODES)
-        self._hvac_power_on = config.get(CONF_HVAC_POWER_ON, DEFAULT_HVAC_POWER_ON)
-        self._dry_min_temp = config.get(CONF_DRY_MIN_TEMP, DEFAULT_DRY_MIN_TEMP)
-        self._dry_min_fan = config.get(CONF_DRY_MIN_FAN, DEFAULT_DRY_MIN_FAN)
-
+class TuyaClimate(ClimateEntity, RestoreEntity, CoordinatorEntity, TuyaEntity):
+    def __init__(self, config, coordinator, registry):
+        TuyaEntity.__init__(self, config, registry)
         super().__init__(coordinator, context=self._climate_id)
-
-        self._hvac_mode = HVACMode.OFF
-        self._target_temperature = 0
-        self._fan_mode = FAN_AUTO
 
     @property
     def name(self):
@@ -77,17 +37,12 @@ class TuyaClimate(ClimateEntity, RestoreEntity, CoordinatorEntity):
 
     @property
     def unique_id(self):
-        return f"{self._infrared_id}_{self._climate_id}"
+        return self.climate_unique_id()
 
     @property
     def device_info(self):
-        return {
-            "name": self._name,
-            "identifiers": {(DOMAIN, self._climate_id)},
-            "via_device": (DOMAIN, self._infrared_id),
-            "manufacturer": MANUFACTURER
-        }
-        
+        return self.tuya_device_info()
+
     @property
     def available(self):
         return self.coordinator.is_available(self._climate_id)
@@ -115,28 +70,16 @@ class TuyaClimate(ClimateEntity, RestoreEntity, CoordinatorEntity):
     @property
     def current_temperature(self):
         sensor_state = self.hass.states.get(self._temperature_sensor) if self._temperature_sensor is not None else None
-        return float(sensor_state.state) if sensor_state and sensor_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE] else None
+        return float(sensor_state.state) if valid_sensor_state(sensor_state) else None
 
     @property
     def current_humidity(self):
         sensor_state = self.hass.states.get(self._humidity_sensor) if self._humidity_sensor is not None else None
-        return float(sensor_state.state) if sensor_state and sensor_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE] else None
-
-    @property
-    def target_temperature(self):
-        return self._target_temperature
-
-    @property
-    def hvac_mode(self):
-        return self._hvac_mode
+        return float(sensor_state.state) if valid_sensor_state(sensor_state) else None
 
     @property
     def hvac_modes(self):
         return self._hvac_modes
-
-    @property
-    def fan_mode(self):
-        return self._fan_mode
 
     @property
     def fan_modes(self):
@@ -144,20 +87,24 @@ class TuyaClimate(ClimateEntity, RestoreEntity, CoordinatorEntity):
 
     async def async_added_to_hass(self):
         await super().async_added_to_hass()
-
+        self.load_optional_entities()
         last_state = await self.async_get_last_state()
-        if last_state and last_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE]:
-            self._hvac_mode = last_state.state
-            self._target_temperature = last_state.attributes.get("temperature")
-            self._fan_mode = last_state.attributes.get("fan_mode")
+        if valid_sensor_state(last_state):
+            self._attr_hvac_mode = last_state.state
+            self._attr_target_temperature = last_state.attributes.get("temperature")
+            self._attr_fan_mode = last_state.attributes.get("fan_mode")
+        else:
+            self._attr_hvac_mode = HVACMode.OFF
+            self._attr_target_temperature = 0
+            self._attr_fan_mode = FAN_AUTO
 
     @callback
     def _handle_coordinator_update(self):
         data = self.coordinator.data.get(self._climate_id)
         if data:
-            self._hvac_mode = data.hvac_mode if data.power else HVACMode.OFF
-            self._target_temperature = data.temperature
-            self._fan_mode = data.fan_mode
+            self._attr_hvac_mode = data.hvac_mode if data.power else HVACMode.OFF
+            self._attr_target_temperature = data.temperature
+            self._attr_fan_mode = data.fan_mode
             self.async_write_ha_state()
 
     async def async_turn_on(self):
@@ -184,9 +131,8 @@ class TuyaClimate(ClimateEntity, RestoreEntity, CoordinatorEntity):
 
     async def async_set_hvac_mode(self, hvac_mode):
         _LOGGER.info(f"{self.entity_id} setting hvac mode to {hvac_mode}")
-        temperature = (DEFAULT_MIN_TEMP if hvac_mode is HVACMode.DRY and self._dry_min_temp 
-                       else (self._min_temp if self._target_temperature < self._min_temp else self._target_temperature))
-        fan_mode = FAN_LOW if hvac_mode is HVACMode.DRY and self._dry_min_fan else FAN_AUTO
+        temperature = self.get_hvac_temperature(hvac_mode)
+        fan_mode = self.get_hvac_fan_mode(hvac_mode)
         if hvac_mode is HVACMode.OFF:
             await self.coordinator.async_turn_off(self._infrared_id, self._climate_id)
         else:

--- a/custom_components/tuya_smart_ir_ac/config_flow.py
+++ b/custom_components/tuya_smart_ir_ac/config_flow.py
@@ -1,8 +1,22 @@
 import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
-from homeassistant.core import callback
-from homeassistant.helpers import selector
 from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import section
+from homeassistant.helpers import entity_registry
+from homeassistant.helpers.selector import (
+    BooleanSelector,
+    EntitySelector,
+    EntitySelectorConfig,
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType
+)
 from homeassistant.const import (
     CONF_NAME,
     Platform
@@ -19,6 +33,9 @@ from .const import (
     CONF_TEMP_STEP,
     CONF_HVAC_MODES,
     CONF_FAN_MODES,
+    CONF_TEMP_HVAC_MODE,
+    CONF_FAN_HVAC_MODE,
+    CONF_COMPATIBILITY_OPTIONS,
     CONF_HVAC_POWER_ON,
     CONF_DRY_MIN_TEMP,
     CONF_DRY_MIN_FAN,
@@ -27,6 +44,8 @@ from .const import (
     DEFAULT_PRECISION,
     DEFAULT_HVAC_MODES,
     DEFAULT_FAN_MODES,
+    DEFAULT_TEMP_HVAC_MODE,
+    DEFAULT_FAN_HVAC_MODE,
     DEFAULT_HVAC_POWER_ON,
     DEFAULT_DRY_MIN_TEMP,
     DEFAULT_DRY_MIN_FAN
@@ -38,23 +57,26 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     MINOR_VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
-    
+
     async def async_step_user(self, user_input):
         errors = {}
-
         domain_config  = self.hass.data.get(DOMAIN, {})
         client = domain_config.get(CLIENT, None)
         if client is None:
             return self.async_abort(reason="credentials")
 
         if user_input is not None:
+            overwrite_invalid_user_input(user_input)
             infrared_id = user_input.get(CONF_INFRARED_ID)
             climate_id = user_input.get(CONF_CLIMATE_ID)
-            
-            if await TuyaAPI(self.hass, client).async_fetch_data(infrared_id, climate_id):
+            registry = entity_registry.async_get(self.hass)
+            entity_id = registry.async_get_entity_id(Platform.CLIMATE, DOMAIN, f"{infrared_id}_{climate_id}")
+            if entity_id is not None:
+                errors["base"] = "already_configured"
+            elif not await async_is_valid_device(self.hass, client, infrared_id, climate_id):
+                errors["base"] = "connection"
+            else:
                 return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
-            
-            errors["base"] = "connection"
 
         data = {}
         data.update(required_data())
@@ -74,9 +96,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input):
         return await self.async_step_user(user_input)
-        
+
     async def async_step_user(self, user_input):
         if user_input is not None:
+            overwrite_invalid_user_input(user_input)
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=self.config_entry.data | user_input
             )
@@ -89,20 +112,28 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
 def required_data():
     return {
-        vol.Required(CONF_INFRARED_ID): cv.string,
-        vol.Required(CONF_CLIMATE_ID): cv.string,
-        vol.Required(CONF_NAME): cv.string
+        vol.Required(CONF_INFRARED_ID): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.TEXT)
+        ),
+        vol.Required(CONF_CLIMATE_ID): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.TEXT)
+        ),
+        vol.Required(CONF_NAME): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.TEXT)
+        )
     }
-    
+
 def optional_data(config=None):
     if config is None:
         temperature_sensor = vol.Optional(CONF_TEMPERATURE_SENSOR)
         humidity_sensor = vol.Optional(CONF_HUMIDITY_SENSOR)
-        temp_min = vol.Optional(CONF_TEMP_MIN, default=DEFAULT_MIN_TEMP)
-        temp_max = vol.Optional(CONF_TEMP_MAX, default=DEFAULT_MAX_TEMP)
-        temp_step = vol.Optional(CONF_TEMP_STEP, default=DEFAULT_PRECISION)
-        hvac_modes = vol.Optional(CONF_HVAC_MODES, default=DEFAULT_HVAC_MODES)
-        fan_modes = vol.Optional(CONF_FAN_MODES, default=DEFAULT_FAN_MODES)
+        temp_min = vol.Required(CONF_TEMP_MIN, default=DEFAULT_MIN_TEMP)
+        temp_max = vol.Required(CONF_TEMP_MAX, default=DEFAULT_MAX_TEMP)
+        temp_step = vol.Required(CONF_TEMP_STEP, default=DEFAULT_PRECISION)
+        hvac_modes = vol.Required(CONF_HVAC_MODES, default=DEFAULT_HVAC_MODES)
+        fan_modes = vol.Required(CONF_FAN_MODES, default=DEFAULT_FAN_MODES)
+        temp_hvac_mode = vol.Optional(CONF_TEMP_HVAC_MODE, default=DEFAULT_TEMP_HVAC_MODE)
+        fan_hvac_mode = vol.Optional(CONF_FAN_HVAC_MODE, default=DEFAULT_FAN_HVAC_MODE)
         hvac_power_on = vol.Optional(CONF_HVAC_POWER_ON, default=DEFAULT_HVAC_POWER_ON)
         dry_min_temp = vol.Optional(CONF_DRY_MIN_TEMP, default=DEFAULT_DRY_MIN_TEMP)
         dry_min_fan = vol.Optional(CONF_DRY_MIN_FAN, default=DEFAULT_DRY_MIN_FAN)
@@ -111,75 +142,72 @@ def optional_data(config=None):
             temperature_sensor = vol.Optional(CONF_TEMPERATURE_SENSOR)
         else:
             temperature_sensor = vol.Optional(CONF_TEMPERATURE_SENSOR, default=config.get(CONF_TEMPERATURE_SENSOR))
-        
+
         if config.get(CONF_TEMPERATURE_SENSOR, None) is None:
             humidity_sensor = vol.Optional(CONF_HUMIDITY_SENSOR)
         else:
             humidity_sensor = vol.Optional(CONF_HUMIDITY_SENSOR, default=config.get(CONF_HUMIDITY_SENSOR))
-        
-        temp_min = vol.Optional(CONF_TEMP_MIN, default=config.get(CONF_TEMP_MIN, DEFAULT_MIN_TEMP))
-        temp_max = vol.Optional(CONF_TEMP_MAX, default=config.get(CONF_TEMP_MAX, DEFAULT_MAX_TEMP))
-        temp_step = vol.Optional(CONF_TEMP_STEP, default=config.get(CONF_TEMP_STEP, DEFAULT_PRECISION))
-        hvac_modes = vol.Optional(CONF_HVAC_MODES, default=config.get(CONF_HVAC_MODES, DEFAULT_HVAC_MODES))
-        fan_modes = vol.Optional(CONF_FAN_MODES, default=config.get(CONF_FAN_MODES, DEFAULT_FAN_MODES))
-        hvac_power_on = vol.Optional(CONF_HVAC_POWER_ON, default=config.get(CONF_HVAC_POWER_ON, DEFAULT_HVAC_POWER_ON))
-        dry_min_temp = vol.Optional(CONF_DRY_MIN_TEMP, default=config.get(CONF_DRY_MIN_TEMP, DEFAULT_DRY_MIN_TEMP))
-        dry_min_fan = vol.Optional(CONF_DRY_MIN_FAN, default=config.get(CONF_DRY_MIN_FAN, DEFAULT_DRY_MIN_FAN))
+
+        temp_min = vol.Required(CONF_TEMP_MIN, default=config.get(CONF_TEMP_MIN, DEFAULT_MIN_TEMP))
+        temp_max = vol.Required(CONF_TEMP_MAX, default=config.get(CONF_TEMP_MAX, DEFAULT_MAX_TEMP))
+        temp_step = vol.Required(CONF_TEMP_STEP, default=config.get(CONF_TEMP_STEP, DEFAULT_PRECISION))
+        hvac_modes = vol.Required(CONF_HVAC_MODES, default=config.get(CONF_HVAC_MODES, DEFAULT_HVAC_MODES))
+        fan_modes = vol.Required(CONF_FAN_MODES, default=config.get(CONF_FAN_MODES, DEFAULT_FAN_MODES))
+        temp_hvac_mode = vol.Optional(CONF_TEMP_HVAC_MODE, default=config.get(CONF_TEMP_HVAC_MODE, DEFAULT_TEMP_HVAC_MODE))
+        fan_hvac_mode = vol.Optional(CONF_FAN_HVAC_MODE, default=config.get(CONF_FAN_HVAC_MODE, DEFAULT_FAN_HVAC_MODE))
+        hvac_power_on = vol.Optional(CONF_HVAC_POWER_ON, default=config.get(CONF_COMPATIBILITY_OPTIONS, {}).get(CONF_HVAC_POWER_ON, DEFAULT_HVAC_POWER_ON))
+        dry_min_temp = vol.Optional(CONF_DRY_MIN_TEMP, default=config.get(CONF_COMPATIBILITY_OPTIONS, {}).get(CONF_DRY_MIN_TEMP, DEFAULT_DRY_MIN_TEMP))
+        dry_min_fan = vol.Optional(CONF_DRY_MIN_FAN, default=config.get(CONF_COMPATIBILITY_OPTIONS, {}).get(CONF_DRY_MIN_FAN, DEFAULT_DRY_MIN_FAN))
 
     return {
-        temperature_sensor: selector.EntitySelector(
-            selector.EntitySelectorConfig(
-                domain=Platform.SENSOR,
-                device_class="temperature",
-                multiple=False
-            )
+        temperature_sensor: EntitySelector(
+            EntitySelectorConfig(domain=Platform.SENSOR, device_class="temperature",  multiple=False)
         ),
-        humidity_sensor: selector.EntitySelector(
-            selector.EntitySelectorConfig(
-                domain=Platform.SENSOR,
-                device_class="humidity",
-                multiple=False
-            )
+        humidity_sensor: EntitySelector(
+            EntitySelectorConfig(domain=Platform.SENSOR, device_class="humidity", multiple=False)
         ),
-        temp_min: selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=DEFAULT_MIN_TEMP,
-                max=DEFAULT_MAX_TEMP,
-                step=1,
-                mode=selector.NumberSelectorMode.BOX
-            )
+        temp_min: NumberSelector(
+            NumberSelectorConfig(min=DEFAULT_MIN_TEMP, max=DEFAULT_MAX_TEMP, step=1, mode=NumberSelectorMode.BOX)
         ),
-        temp_max: selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=DEFAULT_MIN_TEMP,
-                max=DEFAULT_MAX_TEMP,
-                step=1,
-                mode=selector.NumberSelectorMode.BOX
-            )
+        temp_max: NumberSelector(
+            NumberSelectorConfig(min=DEFAULT_MIN_TEMP, max=DEFAULT_MAX_TEMP, step=1, mode=NumberSelectorMode.BOX)
         ),
-        temp_step: selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0.1,
-                max=1,
-                step=0.1,
-                mode=selector.NumberSelectorMode.BOX
-            )
+        temp_step: NumberSelector(
+            NumberSelectorConfig(min=0.1, max=1, step=0.1, mode=NumberSelectorMode.BOX)
         ),
-        hvac_modes: selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=DEFAULT_HVAC_MODES, 
-                multiple=True,
-                mode=selector.SelectSelectorMode.DROPDOWN
-            )
+        hvac_modes: SelectSelector(
+            SelectSelectorConfig(options=DEFAULT_HVAC_MODES, multiple=True, mode=SelectSelectorMode.DROPDOWN, translation_key=CONF_HVAC_MODES)
         ),
-        fan_modes: selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=DEFAULT_FAN_MODES, 
-                multiple=True,
-                mode=selector.SelectSelectorMode.DROPDOWN
-            )
+        fan_modes: SelectSelector(
+            SelectSelectorConfig(options=DEFAULT_FAN_MODES, multiple=True, mode=SelectSelectorMode.DROPDOWN, translation_key=CONF_FAN_MODES)
         ),
-        hvac_power_on: selector.BooleanSelector(),
-        dry_min_temp: selector.BooleanSelector(),
-        dry_min_fan: selector.BooleanSelector()
+        temp_hvac_mode: BooleanSelector(),
+        fan_hvac_mode: BooleanSelector(),
+        CONF_COMPATIBILITY_OPTIONS: section(
+            vol.Schema(
+                {
+                    hvac_power_on: BooleanSelector(),
+                    dry_min_temp: BooleanSelector(),
+                    dry_min_fan: BooleanSelector()
+                }
+            ),
+            {"collapsed": True}
+        )
     }
+
+def overwrite_invalid_user_input(user_input):
+    hvac_modes = user_input.get(CONF_HVAC_MODES, None)
+    if hvac_modes is not None and len(hvac_modes) == 0:
+        user_input[CONF_HVAC_MODES] = DEFAULT_HVAC_MODES
+
+    fan_modes = user_input.get(CONF_FAN_MODES, None)
+    if fan_modes is not None and len(fan_modes) == 0:
+        user_input[CONF_FAN_MODES] = DEFAULT_FAN_MODES
+
+async def async_is_valid_device(hass, client, infrared_id, climate_id):
+    try:
+        api = TuyaAPI(hass, client)
+        result = await api.async_fetch_data(infrared_id, climate_id)
+        return result
+    except Exception as e:
+        return False

--- a/custom_components/tuya_smart_ir_ac/const.py
+++ b/custom_components/tuya_smart_ir_ac/const.py
@@ -15,7 +15,7 @@ COORDINATOR = "COORDINATOR"
 FIRST_UPDATE = 5
 UPDATE_INTERVAL = 60
 UPDATE_TIMEOUT = 15
-PLATFORMS = [Platform.CLIMATE]
+PLATFORMS = [Platform.NUMBER, Platform.SELECT, Platform.CLIMATE]
 
 CONF_ACCESS_ID = "access_id"
 CONF_ACCESS_SECRET = "access_secret"
@@ -29,6 +29,9 @@ CONF_TEMP_MAX = "max_temp"
 CONF_TEMP_STEP = "temp_step"
 CONF_HVAC_MODES = "hvac_modes"
 CONF_FAN_MODES = "fan_modes"
+CONF_TEMP_HVAC_MODE = "temp_hvac_mode"
+CONF_FAN_HVAC_MODE = "fan_hvac_mode"
+CONF_COMPATIBILITY_OPTIONS = "compatibility_options"
 CONF_HVAC_POWER_ON = "hvac_power_on"
 CONF_DRY_MIN_TEMP = "dry_min_temp"
 CONF_DRY_MIN_FAN = "dry_min_fan"
@@ -36,16 +39,24 @@ CONF_DRY_MIN_FAN = "dry_min_fan"
 DEFAULT_MIN_TEMP = 16
 DEFAULT_MAX_TEMP = 30
 DEFAULT_PRECISION = 1.0
+DEFAULT_TEMP_HVAC_MODE = False
+DEFAULT_FAN_HVAC_MODE = False
 DEFAULT_HVAC_POWER_ON = False
 DEFAULT_DRY_MIN_TEMP = False
 DEFAULT_DRY_MIN_FAN = False
 
+DEFAULT_TEMP_HVAC_MODES = [
+    HVACMode.AUTO,
+    HVACMode.COOL,
+    HVACMode.HEAT
+]
+
 DEFAULT_HVAC_MODES = [
+    HVACMode.AUTO,
     HVACMode.COOL,
     HVACMode.HEAT,
-    HVACMode.AUTO,
-    HVACMode.FAN_ONLY,
     HVACMode.DRY,
+    HVACMode.FAN_ONLY,
     HVACMode.OFF
 ]
 

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -3,7 +3,6 @@ import async_timeout
 from datetime import timedelta
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.components.climate.const import HVACMode
 from .helpers import (
     hass_temperature,
     hass_fan_mode,
@@ -50,7 +49,7 @@ class TuyaCoordinator(DataUpdateCoordinator):
             await self._async_force_update_data(climate_id, power=True)
         except Exception:
             raise ServiceValidationError(translation_domain=DOMAIN, translation_key="climate_error_turn_on")
-            
+
     async def async_turn_off(self, infrared_id, climate_id):
         try:
             await self._api.async_send_command(infrared_id, climate_id, "power", "0")

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -1,0 +1,124 @@
+import logging
+from homeassistant.const import (
+    Platform,
+    CONF_NAME
+)
+from homeassistant.components.climate.const import (
+    FAN_AUTO,
+    FAN_LOW,
+    HVACMode
+)
+from .const import (
+    DOMAIN,
+    MANUFACTURER,
+    CONF_INFRARED_ID,
+    CONF_CLIMATE_ID,
+    CONF_TEMPERATURE_SENSOR,
+    CONF_HUMIDITY_SENSOR,
+    CONF_TEMP_MIN,
+    CONF_TEMP_MAX,
+    CONF_TEMP_STEP,
+    CONF_HVAC_MODES,
+    CONF_FAN_MODES,
+    CONF_TEMP_HVAC_MODE,
+    CONF_FAN_HVAC_MODE,
+    CONF_COMPATIBILITY_OPTIONS,
+    CONF_HVAC_POWER_ON,
+    CONF_DRY_MIN_TEMP,
+    CONF_DRY_MIN_FAN,
+    DEFAULT_MIN_TEMP,
+    DEFAULT_MAX_TEMP,
+    DEFAULT_PRECISION,
+    DEFAULT_HVAC_MODES,
+    DEFAULT_FAN_MODES,
+    DEFAULT_TEMP_HVAC_MODE,
+    DEFAULT_FAN_HVAC_MODE,
+    DEFAULT_TEMP_HVAC_MODES,
+    DEFAULT_HVAC_POWER_ON,
+    DEFAULT_DRY_MIN_TEMP,
+    DEFAULT_DRY_MIN_FAN
+)
+
+_LOGGER = logging.getLogger(__package__)
+
+
+class TuyaEntity():
+    def __init__(self, config, registry=None):
+        self._registry = registry
+        self._infrared_id = config.get(CONF_INFRARED_ID)
+        self._climate_id = config.get(CONF_CLIMATE_ID)
+        self._name = config.get(CONF_NAME)
+        self._temperature_sensor = config.get(CONF_TEMPERATURE_SENSOR, None)
+        self._humidity_sensor = config.get(CONF_HUMIDITY_SENSOR, None)
+        self._min_temp = config.get(CONF_TEMP_MIN, DEFAULT_MIN_TEMP)
+        self._max_temp = config.get(CONF_TEMP_MAX, DEFAULT_MAX_TEMP)
+        self._temp_step = config.get(CONF_TEMP_STEP, DEFAULT_PRECISION)
+        self._hvac_modes = config.get(CONF_HVAC_MODES, DEFAULT_HVAC_MODES)
+        self._fan_modes = config.get(CONF_FAN_MODES, DEFAULT_FAN_MODES)
+        self._temp_hvac_mode = config.get(CONF_TEMP_HVAC_MODE, DEFAULT_TEMP_HVAC_MODE)
+        self._fan_hvac_mode = config.get(CONF_FAN_HVAC_MODE, DEFAULT_FAN_HVAC_MODE)
+        self._hvac_power_on = config.get(CONF_COMPATIBILITY_OPTIONS, {}).get(CONF_HVAC_POWER_ON, DEFAULT_HVAC_POWER_ON)
+        self._dry_min_temp = config.get(CONF_COMPATIBILITY_OPTIONS, {}).get(CONF_DRY_MIN_TEMP, DEFAULT_DRY_MIN_TEMP)
+        self._dry_min_fan = config.get(CONF_COMPATIBILITY_OPTIONS, {}).get(CONF_DRY_MIN_FAN, DEFAULT_DRY_MIN_FAN)
+
+    def tuya_device_info(self):
+        return {
+            "name": self._name,
+            "identifiers": {(DOMAIN, self._climate_id)},
+            "via_device": (DOMAIN, self._infrared_id),
+            "manufacturer": MANUFACTURER
+        }
+
+    def climate_unique_id(self):
+        return f"{self._infrared_id}_{self._climate_id}"
+
+    def number_unique_id(self, temp_hvac_mode):
+        return f"{self.climate_unique_id()}_{CONF_TEMP_HVAC_MODE}_{temp_hvac_mode}"
+
+    def select_unique_id(self):
+        return f"{self.climate_unique_id()}_{CONF_FAN_HVAC_MODE}"
+
+    def load_optional_entities(self):
+        self._hvac_temp_entities = self.load_hvac_temp_entities()
+        self._hvac_fan_entity = self.load_hvac_fan_entity()
+
+    def load_hvac_temp_entities(self):
+        hvac_temp_entities = {}
+        if self._temp_hvac_mode:
+            for hvac_mode in DEFAULT_TEMP_HVAC_MODES:
+                entity_id = self._registry.async_get_entity_id(Platform.NUMBER, DOMAIN, self.number_unique_id(hvac_mode))
+                if entity_id:
+                    hvac_temp_entities[hvac_mode] = entity_id
+        return hvac_temp_entities
+
+    def load_hvac_fan_entity(self):
+        hvac_fan_entity = None
+        if self._fan_hvac_mode:
+            entity_id = self._registry.async_get_entity_id(Platform.SELECT, DOMAIN, self.select_unique_id())
+            if entity_id:
+                hvac_fan_entity = entity_id
+        return hvac_fan_entity
+
+    def get_hvac_temperature(self, hvac_mode):
+        if hvac_mode in self._hvac_temp_entities:
+            entity_id = self._hvac_temp_entities.get(hvac_mode)
+            number_state = self.hass.states.get(entity_id)
+            return float(number_state.state)
+
+        if hvac_mode is HVACMode.DRY and self._dry_min_temp:
+            return DEFAULT_MIN_TEMP
+
+        if self.target_temperature < self._min_temp:
+            return self._min_temp
+
+        return self.target_temperature
+
+    def get_hvac_fan_mode(self, hvac_mode):
+        if hvac_mode is HVACMode.DRY:
+            return FAN_LOW if self._dry_min_fan else FAN_AUTO
+
+        if self._hvac_fan_entity is not None:
+            select_state = self.hass.states.get(self._hvac_fan_entity)
+            return select_state.state
+
+        return self.fan_mode

--- a/custom_components/tuya_smart_ir_ac/helpers.py
+++ b/custom_components/tuya_smart_ir_ac/helpers.py
@@ -1,3 +1,7 @@
+from homeassistant.const import (
+    STATE_UNKNOWN, 
+    STATE_UNAVAILABLE
+)
 from .const import (
     TUYA_HVAC_MODES,
     TUYA_FAN_MODES
@@ -27,3 +31,9 @@ def hass_fan_mode(wind):
 
 def hass_temperature(temperature):
     return float(temperature)
+
+def valid_sensor_state(sensor_state):
+    return sensor_state is not None and sensor_state.state not in [STATE_UNKNOWN, STATE_UNAVAILABLE]
+
+def valid_number_data(number_data):
+    return number_data is not None and number_data.native_value is not None

--- a/custom_components/tuya_smart_ir_ac/manifest.json
+++ b/custom_components/tuya_smart_ir_ac/manifest.json
@@ -8,5 +8,5 @@
    "iot_class": "cloud_polling",
    "issue_tracker": "https://github.com/EnzoD86/tuya-smart-ir-ac/issues",
    "requirements": ["tuya-connector-python==0.1.2"],
-   "version": "2024.9.1"
+   "version": "2024.9.2"
 }

--- a/custom_components/tuya_smart_ir_ac/number.py
+++ b/custom_components/tuya_smart_ir_ac/number.py
@@ -1,0 +1,80 @@
+from homeassistant.components.number import RestoreNumber
+from homeassistant.components.number.const import (
+    NumberDeviceClass,
+    NumberMode
+)
+from homeassistant.const import (
+    EntityCategory,
+    UnitOfTemperature
+)
+from .const import (
+    CONF_TEMP_HVAC_MODE,
+    DEFAULT_TEMP_HVAC_MODE,
+    DEFAULT_TEMP_HVAC_MODES
+)
+from .helpers import valid_number_data
+from .entity import TuyaEntity
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    temp_hvac_mode = config_entry.data.get(CONF_TEMP_HVAC_MODE, DEFAULT_TEMP_HVAC_MODE)
+    if temp_hvac_mode:
+        async_add_entities(TuyaNumber(config_entry.data, temp_hvac_mode) for temp_hvac_mode in DEFAULT_TEMP_HVAC_MODES)
+
+
+class TuyaNumber(RestoreNumber, TuyaEntity):
+    def __init__(self, config, temp_hvac_mode):
+        RestoreNumber.__init__(self)
+        TuyaEntity.__init__(self, config)
+        self._temp_hvac_mode = temp_hvac_mode
+
+    @property
+    def has_entity_name(self):
+        return True
+
+    @property
+    def translation_key(self):
+        return f"{CONF_TEMP_HVAC_MODE}_{self._temp_hvac_mode}"
+
+    @property
+    def unique_id(self):
+        return self.number_unique_id(self._temp_hvac_mode)
+
+    @property
+    def device_info(self):
+        return self.tuya_device_info()
+
+    @property
+    def entity_category(self):
+        return EntityCategory.CONFIG
+
+    @property
+    def device_class(self):
+        return NumberDeviceClass.TEMPERATURE
+
+    @property
+    def mode(self):
+        return NumberMode.SLIDER
+
+    @property
+    def native_min_value(self):
+        return self._min_temp
+
+    @property
+    def native_max_value(self):
+        return self._max_temp
+
+    @property
+    def native_step(self):
+        return self._temp_step
+
+    @property
+    def native_unit_of_measurement(self):
+        return UnitOfTemperature.CELSIUS
+
+    async def async_added_to_hass(self):
+        last_number = await self.async_get_last_number_data()
+        self._attr_native_value = last_number.native_value if valid_number_data(last_number) else (self._min_temp + self._max_temp) / 2
+
+    async def async_set_native_value(self, value):
+        self._attr_native_value = value

--- a/custom_components/tuya_smart_ir_ac/select.py
+++ b/custom_components/tuya_smart_ir_ac/select.py
@@ -1,0 +1,59 @@
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import (
+    EntityCategory,
+    STATE_UNKNOWN, 
+    STATE_UNAVAILABLE
+)
+from .const import (
+    CONF_FAN_HVAC_MODE,
+    DEFAULT_FAN_HVAC_MODE
+)
+from .helpers import valid_sensor_state
+from .entity import TuyaEntity
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    fan_hvac_mode = config_entry.data.get(CONF_FAN_HVAC_MODE, DEFAULT_FAN_HVAC_MODE)
+    if fan_hvac_mode:
+        async_add_entities([TuyaSelect(config_entry.data)])
+
+
+class TuyaSelect(SelectEntity, RestoreEntity, TuyaEntity):
+    def __init__(self, config):
+        TuyaEntity.__init__(self, config)
+
+    @property
+    def has_entity_name(self):
+        return True
+
+    @property
+    def translation_key(self):
+        return f"{CONF_FAN_HVAC_MODE}"
+
+    @property
+    def unique_id(self):
+        return self.select_unique_id()
+
+    @property
+    def device_info(self):
+        return self.tuya_device_info()
+
+    @property
+    def entity_category(self):
+        return EntityCategory.CONFIG
+
+    @property
+    def icon(self):
+        return "mdi:fan"
+
+    @property
+    def options(self):
+        return self._fan_modes
+
+    async def async_added_to_hass(self):
+        last_state = await self.async_get_last_state()
+        self._attr_current_option = last_state.state if valid_sensor_state(last_state) else self._fan_modes[0]
+
+    async def async_select_option(self, option):
+        self._attr_current_option = option

--- a/custom_components/tuya_smart_ir_ac/translations/en.json
+++ b/custom_components/tuya_smart_ir_ac/translations/en.json
@@ -1,50 +1,111 @@
 {
+  "entity": {
+    "number": {
+      "temp_hvac_mode_auto": {
+        "name": "Auto"
+      },
+      "temp_hvac_mode_cool": {
+        "name": "Cool"
+      },
+      "temp_hvac_mode_heat": {
+        "name": "Heat"
+      }
+    },
+    "select": {
+      "fan_hvac_mode": {
+        "name": "Fan speed",
+        "state": {
+          "auto": "Auto",
+          "low": "Low",
+          "medium": "Medium",
+          "high": "High"
+        }
+      }
+    }
+  },
+  "selector": {
+    "hvac_modes": {
+      "options": {
+        "auto": "Auto",
+        "cool": "Cool",
+        "heat": "Heat",
+        "dry": "Dry",
+        "fan_only": "Fan only",
+        "off": "Off"
+      }
+    },
+    "fan_modes": {
+      "options": {
+        "auto": "Auto",
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High"
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {
+        "title": "Air conditioner configuration",
         "data": {
-          "infrared_id": "Infrared ID",
-          "climate_id": "Climate ID",
+          "infrared_id": "Infrared hub ID",
+          "climate_id": "Air conditioner ID",
           "name": "Air conditioner name",
           "temperature_sensor": "Temperature sensor",
           "humidity_sensor": "Humidity sensor",
           "min_temp": "Minimum temperature",
           "max_temp": "Maximum temperature",
           "temp_step": "Step temperature",
-          "hvac_modes": "HVAC modes supported",
-          "fan_modes": "FAN modes supported",
-          "hvac_power_on": "Force power on when setting hvac mode",
-          "dry_min_temp": "Set minimum temperature in dry mode",
-          "dry_min_fan": "Set minimum fan mode in dry mode"
+          "hvac_modes": "Supported HVAC modes",
+          "fan_modes": "Supported FAN modes",
+          "temp_hvac_mode": "Default temperatures when setting HVAC mode",
+          "fan_hvac_mode": "Default fan speed when setting HVAC mode"
         },
-        "description": "Configuration",
-        "title": "Tuya Smart IR Air Conditioners"
+        "sections": {
+          "compatibility_options": {
+            "name": "Compatibility options",
+            "data": {
+              "hvac_power_on": "Force power on when setting HVAC mode",
+              "dry_min_temp": "Set minimum temperature in dry mode",
+              "dry_min_fan": "Set minimum fan speed in dry mode"
+            }
+          }
+        }
       }
     },
     "error": {
-      "connection": "Unable to connect to device. This may be a temporary issue, or the information provided may be incorrect."
+      "already_configured": "This device has already been configured.",
+      "connection": "Could not connect to device; check the log for more information."
     },
     "abort": {
-      "credentials": "Before continuing, you need to add the integration in your configuration.yaml (read the readme)."
+      "credentials": "Before continuing, you need to manually add the integration in your configuration.yaml."
     }
   },
   "options": {
     "step": {
       "user": {
+        "title": "Air conditioner configuration",
         "data": {
           "temperature_sensor": "Temperature sensor",
           "humidity_sensor": "Humidity sensor",
           "min_temp": "Minimum temperature",
           "max_temp": "Maximum temperature",
           "temp_step": "Step temperature",
-          "hvac_modes": "HVAC modes supported",
-          "fan_modes": "FAN modes supported",
-          "hvac_power_on": "Force power on when setting hvac mode",
-          "dry_min_temp": "Set minimum temperature in dry mode",
-          "dry_min_fan": "Set minimum fan speed in dry mode"
+          "hvac_modes": "Supported HVAC modes",
+          "fan_modes": "Supported FAN modes",
+          "temp_hvac_mode": "Default temperatures when setting HVAC mode",
+          "fan_hvac_mode": "Default fan speed when setting HVAC mode"
         },
-        "description": "Configurazione",
-        "title": "Tuya Smart IR Air Conditioners"
+        "sections": {
+          "compatibility_options": {
+            "name": "Compatibility options",
+            "data": {
+              "hvac_power_on": "Force power on when setting hvac mode",
+              "dry_min_temp": "Set minimum temperature in dry mode",
+              "dry_min_fan": "Set minimum fan speed in dry mode"
+            }
+          }
+        }
       }
     }
   },

--- a/custom_components/tuya_smart_ir_ac/translations/it.json
+++ b/custom_components/tuya_smart_ir_ac/translations/it.json
@@ -1,11 +1,63 @@
 {
+  "entity": {
+    "number": {
+      "temp_hvac_mode_auto": {
+        "name": "Auto"
+      },
+      "temp_hvac_mode_cool": {
+        "name": "Freddo"
+      },
+      "temp_hvac_mode_heat": {
+        "name": "Caldo"
+      }
+    },
+    "select": {
+      "fan_hvac_mode": {
+        "name": "Velocità ventola",
+        "state": {
+          "auto": "Auto",
+          "low": "Basso",
+          "medium": "Medio",
+          "high": "Alto"
+        }
+      }
+    }
+  },
+  "selector": {
+    "hvac_modes": {
+      "options": {
+        "auto": "Auto",
+        "cool": "Freddo",
+        "heat": "Caldo",
+        "dry": "Deumidificazione",
+        "fan_only": "Solo ventilatore",
+        "off": "Spento"
+      }
+    },
+    "fan_modes": {
+      "options": {
+        "auto": "Auto",
+        "low": "Basso",
+        "medium": "Medio",
+        "high": "Alto"
+      }
+    },
+    "temp_hvac_modes": {
+      "options": {
+        "auto": "Auto",
+        "cool": "Freddo",
+        "heat": "Caldo"
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {
+        "title": "Configurazione climatizzatore",
         "data": {
-          "infrared_id": "Infrared ID",
-          "climate_id": "Climate ID",
-          "name": "Nome condizionatore",
+          "infrared_id": "ID hub infrarossi",
+          "climate_id": "ID climatizzatore",
+          "name": "Nome climatizzatore",
           "temperature_sensor": "Sensore temperatura",
           "humidity_sensor": "Sensore umidità",
           "min_temp": "Temperatura minima",
@@ -13,24 +65,33 @@
           "temp_step": "Temperatura step",
           "hvac_modes": "Modalità HVAC supportate",
           "fan_modes": "Modalità FAN supportate",
-          "hvac_power_on": "Forza l'accensione quando si imposta la modalità HVAC",
-          "dry_min_temp": "Imposta temperatura minima in modalità deumidificazione",
-          "dry_min_fan": "Imposta ventola al minimo in modalità deumidificazione"
+          "temp_hvac_mode": "Temperature di default quando si imposta la modalità HVAC",
+          "fan_hvac_mode": "Velocità ventola di default quando si imposta la modalità HVAC"
         },
-        "description": "Configurazione",
-        "title": "Tuya Smart IR Air Conditioners"
+        "sections": {
+          "compatibility_options": {
+            "name": "Opzioni di compatibilità",
+            "data": {
+              "hvac_power_on": "Forza l'accensione quando si imposta la modalità HVAC",
+              "dry_min_temp": "Imposta temperatura minima in modalità deumidificazione",
+              "dry_min_fan": "Imposta ventola al minimo in modalità deumidificazione"
+            }
+          }
+        }
       }
     },
     "error": {
-      "connection": "Impossibile connettersi al dispositivo. Può trattarsi di un problema temporaneo, oppure le informazioni fornite potrebbero non essere corrette."
+      "already_configured": "Questo dispositivo è già stato configurato.",
+      "connection": "Impossibile connettersi al dispositivo; controlla il log per maggiori informazioni."
     },
     "abort": {
-      "credentials": "Prima di proseguire, è necessario aggiungere l'integrazione nel configuration.yaml (leggi il readme)."
+      "credentials": "Prima di proseguire, è necessario aggiungere manualmente l'integrazione nel configuration.yaml."
     }
   },
   "options": {
     "step": {
       "user": {
+        "title": "Configurazione climatizzatore",
         "data": {
           "temperature_sensor": "Sensore temperatura",
           "humidity_sensor": "Sensore umidità",
@@ -39,12 +100,19 @@
           "temp_step": "Temperatura step",
           "hvac_modes": "Modalità HVAC supportate",
           "fan_modes": "Modalità FAN supportate",
-          "hvac_power_on": "Forza l'accensione quando si imposta la modalità HVAC",
-          "dry_min_temp": "Imposta temperatura minima in modalità deumidificazione",
-          "dry_min_fan": "Imposta ventola al minimo in modalità deumidificazione"
+          "temp_hvac_mode": "Temperature di default quando si imposta la modalità HVAC",
+          "fan_hvac_mode": "Velocità ventola di default quando si imposta la modalità HVAC"
         },
-        "description": "Configurazione",
-        "title": "Tuya Smart IR Air Conditioners"
+        "sections": {
+          "compatibility_options": {
+            "name": "Opzioni di compatibilità",
+            "data": {
+              "hvac_power_on": "Forza l'accensione quando si imposta la modalità HVAC",
+              "dry_min_temp": "Imposta temperatura minima in modalità deumidificazione",
+              "dry_min_fan": "Imposta ventola al minimo in modalità deumidificazione"
+            }
+          }
+        }
       }
     }
   },

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Tuya Smart IR AC",
-  "homeassistant": "2024.1.0"
+  "homeassistant": "2024.9.2"
 }


### PR DESCRIPTION
## Changelog 2024.9.2
- added default hvac temperatures for automatic, cooling and heating modes that can be activated from configuration UI;
- added default hvac fan speed that can be activated from configuration UI;
- changed fan speed behavior when changing hvac mode: now the fan speed is not changed (except in dry mode or if the new default HVAC fan speed configuration is active);
- updated the configuration UI by grouping the compatibility options in a dedicated collapsed section;
- fixed a configuration issue that allowed the "Supported HVAC Modes" field to be left blank;
- fixed a configuration issue that allowed the "Supported FAN Modes" field to be left blank;
- fixed a configuration issue that allowed the same device to be added multiple times;
- fixed a configuration issue that was showing the unhandled error "Unknown error occurred";
- improved integration translation;
- code refactoring;
- update the minimum required Home Assistant version.