### PR TITLE
Use source sensor unit & normalize current_temperature to °C

### DIFF
--- a/custom_components/tuya_smart_ir_ac/climate.py
+++ b/custom_components/tuya_smart_ir_ac/climate.py
@@ -91,11 +91,9 @@ class TuyaClimate(ClimateEntity, RestoreEntity, CoordinatorEntity, TuyaClimateEn
 
         unit = sensor_state.attributes.get("unit_of_measurement")
 
-        if unit == UnitOfTemperature.FAHRENHEIT:
-            # Convert °F → °C
-            return TemperatureConverter.convert(value, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS)
-        
-        # Already °C (or no unit info, assume °C)
+        if unit != self.temperature_unit:
+            return TemperatureConverter.convert(value, unit, self.temperature_unit)
+
         return value
     
     @property

--- a/custom_components/tuya_smart_ir_ac/sensor.py
+++ b/custom_components/tuya_smart_ir_ac/sensor.py
@@ -61,7 +61,11 @@ class TuyaTemperatureSensor(SensorEntity, TuyaClimateEntity):
 
     @property    
     def native_unit_of_measurement(self):
-        return UnitOfTemperature.CELSIUS
+        if self._temperature_sensor:
+            sensor_state = self.hass.states.get(self._temperature_sensor)
+            if sensor_state is not None:
+                return sensor_state.attributes.get("unit_of_measurement")
+        return UnitOfTemperature.CELSIUS  # fallback
 
     @property
     def native_value(self):


### PR DESCRIPTION
* Temperature sensor entity now **reports the same unit** as its source temperature sensor. 
* Climate entity’s `current_temperature` now **converts from °F → °C when the source sensor is in Fahrenheit**, so the entity’s **native** unit stays Celsius (letting HA display in the user’s preferred unit).
* Fixes: #61 