### PR TITLE
2026.6.3

### DIFF
--- a/custom_components/tuya_smart_ir_ac/config_flow.py
+++ b/custom_components/tuya_smart_ir_ac/config_flow.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_ACCESS_SECRET,
     CONF_CLIMATE_UPDATE_INTERVAL,
     CONF_COMPATIBILITY_OPTIONS,
+    CONF_CUSTOM_POWER_ON,
     CONF_DEVICE_ID,
     CONF_DRY_MIN_FAN,
     CONF_DRY_MIN_TEMP,
@@ -783,6 +784,12 @@ def climate_data() -> dict[vol.Marker, Any]:
                     vol.Optional(
                         CONF_DRY_MIN_FAN, default=DEFAULT_DRY_MIN_FAN
                     ): BooleanSelector(),
+                    vol.Optional(CONF_CUSTOM_POWER_ON): EntitySelector(
+                        EntitySelectorConfig(
+                            domain=Platform.BUTTON,
+                            multiple=False,
+                        )
+                    )
                 }
             ),
             {"collapsed": True},

--- a/custom_components/tuya_smart_ir_ac/const.py
+++ b/custom_components/tuya_smart_ir_ac/const.py
@@ -66,6 +66,7 @@ CONF_TEMP_POWER_ON = "temp_power_on"
 CONF_FAN_POWER_ON = "fan_power_on"
 CONF_DRY_MIN_TEMP = "dry_min_temp"
 CONF_DRY_MIN_FAN = "dry_min_fan"
+CONF_CUSTOM_POWER_ON = "custom_power_on"
 CONF_SENSOR_TYPES = "sensor_types"
 CONF_TEMP_UNIT = "temp_unit"
 

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -4,6 +4,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.const import (
     UnitOfTemperature,
+    Platform,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_NAME,
 )
@@ -34,6 +35,7 @@ from .const import (
     CONF_FAN_POWER_ON,
     CONF_DRY_MIN_TEMP,
     CONF_DRY_MIN_FAN,
+    CONF_CUSTOM_POWER_ON,
     DEFAULT_MIN_TEMP,
     DEFAULT_MAX_TEMP,
     DEFAULT_PRECISION,
@@ -87,6 +89,7 @@ class TuyaClimateEntity:
         self._fan_power_on = compatibility.get(CONF_FAN_POWER_ON, DEFAULT_FAN_POWER_ON)
         self._dry_min_temp = compatibility.get(CONF_DRY_MIN_TEMP, DEFAULT_DRY_MIN_TEMP)
         self._dry_min_fan = compatibility.get(CONF_DRY_MIN_FAN, DEFAULT_DRY_MIN_FAN)
+        self._custom_power_on = compatibility.get(CONF_CUSTOM_POWER_ON)
 
         base_id = f"{self._infrared_id}_{self._climate_id}"
         self._attr_unique_id = f"{base_id}_{sub_entity_type}" if sub_entity_type else base_id
@@ -258,6 +261,7 @@ class TuyaClimateEntity:
     async def async_handle_turn_on(self) -> None:
         """Turn on the climate device power via coordinator service."""
         await self.coordinator.async_turn_on(self._infrared_id, self._climate_id)
+        await self._async_trigger_custom_on_if_configured()
 
     async def async_handle_turn_off(self) -> None:
         """Turn off the climate device power via coordinator service."""
@@ -273,6 +277,7 @@ class TuyaClimateEntity:
         fan_mode = self.get_hvac_fan_mode(hvac_mode)
 
         if self.get_hvac_power_on(self._current_hvac_mode):
+            await self._async_trigger_custom_on_if_configured()
             await self.coordinator.async_turn_on_with_hvac_mode(
                 self._infrared_id, self._climate_id, hvac_mode, temperature, fan_mode
             )
@@ -290,6 +295,7 @@ class TuyaClimateEntity:
                 fan_mode = self.get_hvac_fan_mode(hvac_mode)
 
                 if self.get_hvac_power_on(self._current_hvac_mode):
+                    await self._async_trigger_custom_on_if_configured()
                     await self.coordinator.async_turn_on_with_hvac_mode(
                         self._infrared_id, self._climate_id, hvac_mode, value, fan_mode
                     )
@@ -299,6 +305,7 @@ class TuyaClimateEntity:
                     )
         else:
             if self.get_temp_power_on(self._current_hvac_mode):
+                await self._async_trigger_custom_on_if_configured()
                 await self.coordinator.async_turn_on_with_temperature(
                     self._infrared_id, self._climate_id, value
                 )
@@ -310,6 +317,7 @@ class TuyaClimateEntity:
     async def async_handle_set_fan_mode(self, fan_mode: str) -> None:
         """Set fan mode for the climate device via coordinator service."""
         if self.get_fan_power_on(self._current_hvac_mode):
+            await self._async_trigger_custom_on_if_configured()
             await self.coordinator.async_turn_on_with_fan_mode(
                 self._infrared_id, self._climate_id, fan_mode
             )
@@ -317,6 +325,19 @@ class TuyaClimateEntity:
             await self.coordinator.async_set_fan_mode(
                 self._infrared_id, self._climate_id, fan_mode
             )
+
+    async def _async_trigger_custom_on_if_configured(self) -> None:
+        """Trigger the custom hardware alternative power-on button if configured."""
+        if not self._custom_power_on:
+            return
+
+        await self.hass.services.async_call(
+            domain=Platform.BUTTON,
+            service="press",
+            service_data={"entity_id": self._custom_power_on},
+            blocking=True
+        )
+
 
 class TuyaSensorEntity:
     """Base class for standalone environmental Temperature/Humidity sensor devices managed by this integration."""

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -260,8 +260,8 @@ class TuyaClimateEntity:
 
     async def async_handle_turn_on(self) -> None:
         """Turn on the climate device power via coordinator service."""
-        await self.coordinator.async_turn_on(self._infrared_id, self._climate_id)
         await self._async_trigger_custom_on_if_configured()
+        await self.coordinator.async_turn_on(self._infrared_id, self._climate_id)
 
     async def async_handle_turn_off(self) -> None:
         """Turn off the climate device power via coordinator service."""

--- a/custom_components/tuya_smart_ir_ac/translations/de-DE.json
+++ b/custom_components/tuya_smart_ir_ac/translations/de-DE.json
@@ -207,7 +207,8 @@
               "temp_power_on": "Beim Einstellen der Temperatur einschalten erzwingen",
               "fan_power_on": "Beim Einstellen der Ventilatorgeschwindigkeit einschalten erzwingen",
               "dry_min_temp": "Mindesttemperatur im Entfeuchtungsmodus festlegen",
-              "dry_min_fan": "Minimale Ventilatorgeschwindigkeit im Entfeuchtungsmodus festlegen"
+              "dry_min_fan": "Minimale Ventilatorgeschwindigkeit im Entfeuchtungsmodus festlegen",
+              "custom_power_on": "Benutzerdefinierte Einschalttaste (NUR wenn das standardmäßige Einschalten fehlschlägt)"
             }
           }
         }
@@ -234,7 +235,8 @@
               "temp_power_on": "Beim Einstellen der Temperatur einschalten erzwingen",
               "fan_power_on": "Beim Einstellen der Ventilatorgeschwindigkeit einschalten erzwingen",
               "dry_min_temp": "Mindesttemperatur im Entfeuchtungsmodus festlegen",
-              "dry_min_fan": "Minimale Ventilatorgeschwindigkeit im Entfeuchtungsmodus festlegen"
+              "dry_min_fan": "Minimale Ventilatorgeschwindigkeit im Entfeuchtungsmodus festlegen",
+              "custom_power_on": "Benutzerdefinierte Einschalttaste (NUR wenn das standardmäßige Einschalten fehlschlägt)"
             }
           }
         }

--- a/custom_components/tuya_smart_ir_ac/translations/en.json
+++ b/custom_components/tuya_smart_ir_ac/translations/en.json
@@ -207,7 +207,8 @@
               "temp_power_on": "Force power on when setting temperature",
               "fan_power_on": "Force power on when setting fan speed",
               "dry_min_temp": "Set minimum temperature in dry mode",
-              "dry_min_fan": "Set minimum fan speed in dry mode"
+              "dry_min_fan": "Set minimum fan speed in dry mode",
+              "custom_power_on": "Custom power-on button (ONLY if standard power-on fails)"
             }
           }
         }
@@ -234,7 +235,8 @@
               "temp_power_on": "Force power on when setting temperature",
               "fan_power_on": "Force power on when setting fan speed",
               "dry_min_temp": "Set minimum temperature in dry mode",
-              "dry_min_fan": "Set minimum fan speed in dry mode"
+              "dry_min_fan": "Set minimum fan speed in dry mode",
+              "custom_power_on": "Custom power-on button (ONLY if standard power-on fails)"
             }
           }
         }

--- a/custom_components/tuya_smart_ir_ac/translations/fr-FR.json
+++ b/custom_components/tuya_smart_ir_ac/translations/fr-FR.json
@@ -207,7 +207,8 @@
               "temp_power_on": "Forcer l'allumage lors du réglage de la température",
               "fan_power_on": "Forcer l'allumage lors du réglage de la vitesse du ventilateur",
               "dry_min_temp": "Définir la température minimale en mode déshumidification",
-              "dry_min_fan": "Définir la vitesse minimale du ventilateur en mode déshumidification"
+              "dry_min_fan": "Définir la vitesse minimale du ventilateur en mode déshumidification",
+              "custom_power_on": "Bouton de mise sous tension personnalisé (UNIQUEMENT si le bouton de mise sous tension standard ne fonctionne pas)"
             }
           }
         }
@@ -234,7 +235,8 @@
               "temp_power_on": "Forcer l'allumage lors du réglage de la température",
               "fan_power_on": "Forcer l'allumage lors du réglage de la vitesse du ventilateur",
               "dry_min_temp": "Définir la température minimale en mode déshumidification",
-              "dry_min_fan": "Définir la vitesse minimale du ventilateur en mode déshumidification"
+              "dry_min_fan": "Définir la vitesse minimale du ventilateur en mode déshumidification",
+              "custom_power_on": "Bouton de mise sous tension personnalisé (UNIQUEMENT si le bouton de mise sous tension standard ne fonctionne pas)"
             }
           }
         }

--- a/custom_components/tuya_smart_ir_ac/translations/it.json
+++ b/custom_components/tuya_smart_ir_ac/translations/it.json
@@ -207,7 +207,8 @@
               "temp_power_on": "Forza l'accensione quando si imposta la temperatura",
               "fan_power_on": "Forza l'accensione quando si imposta la velocità della ventola",
               "dry_min_temp": "Imposta temperatura minima in modalità deumidificazione",
-              "dry_min_fan": "Imposta ventola al minimo in modalità deumidificazione"
+              "dry_min_fan": "Imposta ventola al minimo in modalità deumidificazione",
+              "custom_power_on": "Pulsante di accensione personalizzato (SOLO se l'accensione standard non funziona)"
             }
           }
         }
@@ -234,7 +235,8 @@
               "temp_power_on": "Forza l'accensione quando si imposta la temperatura",
               "fan_power_on": "Forza l'accensione quando si imposta la velocità della ventola",
               "dry_min_temp": "Imposta temperatura minima in modalità deumidificazione",
-              "dry_min_fan": "Imposta ventola al minimo in modalità deumidificazione"
+              "dry_min_fan": "Imposta ventola al minimo in modalità deumidificazione",
+              "custom_power_on": "Pulsante di accensione personalizzato (SOLO se l'accensione standard non funziona)"
             }
           }
         }

--- a/custom_components/tuya_smart_ir_ac/translations/nl-NL.json
+++ b/custom_components/tuya_smart_ir_ac/translations/nl-NL.json
@@ -207,7 +207,8 @@
               "temp_power_on": "Forceren inschakelen bij instellen temperatuur",
               "fan_power_on": "Forceren inschakelen bij instellen ventilatorsnelheid",
               "dry_min_temp": "Minimale temperatuur instellen in ontvochtigingsmodus",
-              "dry_min_fan": "Minimale ventilatorsnelheid instellen in ontvochtigingsmodus"
+              "dry_min_fan": "Minimale ventilatorsnelheid instellen in ontvochtigingsmodus",
+              "custom_power_on": "Aangepaste aan-knop (ALLEEN inschakelen als standaard aan-knop faalt)"
             }
           }
         }
@@ -234,7 +235,8 @@
               "temp_power_on": "Forceren inschakelen bij instellen temperatuur",
               "fan_power_on": "Forceren inschakelen bij instellen ventilatorsnelheid",
               "dry_min_temp": "Minimale temperatuur instellen in ontvochtigingsmodus",
-              "dry_min_fan": "Minimale ventilatorsnelheid instellen in ontvochtigingsmodus"
+              "dry_min_fan": "Minimale ventilatorsnelheid instellen in ontvochtigingsmodus",
+              "custom_power_on": "Aangepaste aan-knop (ALLEEN inschakelen als standaard aan-knop faalt)"
             }
           }
         }

--- a/custom_components/tuya_smart_ir_ac/translations/pt-BR.json
+++ b/custom_components/tuya_smart_ir_ac/translations/pt-BR.json
@@ -207,7 +207,8 @@
               "temp_power_on": "Forçar ligar ao definir a temperatura",
               "fan_power_on": "Forçar ligar ao definir a velocidade do ventilador",
               "dry_min_temp": "Definir temperatura mínima no modo desumidificar",
-              "dry_min_fan": "Definir velocidade mínima do ventilador no modo desumidificar"
+              "dry_min_fan": "Definir velocidade mínima do ventilador no modo desumidificar",
+              "custom_power_on": "Botão de ligar personalizado (Habilite APENAS se o ligar padrão falhar)"
             }
           }
         }
@@ -234,7 +235,8 @@
               "temp_power_on": "Forçar ligar ao definir a temperatura",
               "fan_power_on": "Forçar ligar ao definir a velocidade do ventilador",
               "dry_min_temp": "Definir temperatura mínima no modo desumidificar",
-              "dry_min_fan": "Definir velocidade mínima do ventilador no modo desumidificar"
+              "dry_min_fan": "Definir velocidade mínima do ventilador no modo desumidificar",
+              "custom_power_on": "Botão de ligar personalizado (Habilite APENAS se o ligar padrão falhar)"
             }
           }
         }

--- a/custom_components/tuya_smart_ir_ac/translations/pt-PT.json
+++ b/custom_components/tuya_smart_ir_ac/translations/pt-PT.json
@@ -206,7 +206,8 @@
               "temp_power_on": "Forçar ligar ao definir a temperatura",
               "fan_power_on": "Forçar ligar ao definir a velocidade da ventoinha",
               "dry_min_temp": "Definir temperatura mínima no modo desumidificar",
-              "dry_min_fan": "Definir velocidade mínima da ventoinha no modo desumidificar"
+              "dry_min_fan": "Definir velocidade mínima da ventoinha no modo desumidificar",
+              "custom_power_on": "Botão de ligar personalizado (Habilite APENAS se o ligar padrão falhar)"
             }
           }
         }
@@ -233,7 +234,8 @@
               "temp_power_on": "Forçar ligar ao definir a temperatura",
               "fan_power_on": "Forçar ligar ao definir a velocidade da ventoinha",
               "dry_min_temp": "Definir temperatura mínima no modo desumidificar",
-              "dry_min_fan": "Definir velocidade mínima da ventoinha no modo desumidificar"
+              "dry_min_fan": "Definir velocidade mínima da ventoinha no modo desumidificar",
+              "custom_power_on": "Botão de ligar personalizado (Habilite APENAS se o ligar padrão falhar)"
             }
           }
         }

--- a/custom_components/tuya_smart_ir_ac/translations/tr.json
+++ b/custom_components/tuya_smart_ir_ac/translations/tr.json
@@ -206,7 +206,8 @@
               "temp_power_on": "Sıcaklığı ayarlarken açmaya zorlayın",
               "fan_power_on": "Fan hızını ayarlarken gücü açmaya zorlayın",
               "dry_min_temp": "Nem alma modunda minimum sıcaklığı ayarla",
-              "dry_min_fan": "Nem alma modunda minimum fan hızını ayarla"
+              "dry_min_fan": "Nem alma modunda minimum fan hızını ayarla",
+              "custom_power_on": "Özel açma düğmesi (SADECE standart açma düğmesi başarısız olursa etkinleştirin)"
             }
           }
         }
@@ -233,7 +234,8 @@
               "temp_power_on": "Sıcaklığı ayarlarken açmaya zorlayın",
               "fan_power_on": "Fan hızını ayarlarken gücü açmaya zorlayın",
               "dry_min_temp": "Nem alma modunda minimum sıcaklığı ayarla",
-              "dry_min_fan": "Nem alma modunda minimum fan hızını ayarla"
+              "dry_min_fan": "Nem alma modunda minimum fan hızını ayarla",
+              "custom_power_on": "Özel açma düğmesi (SADECE standart açma düğmesi başarısız olursa etkinleştirin)"
             }
           }
         }


### PR DESCRIPTION
**Custom Power-On Hardware Alternative:** Added the `Alternative power-on button` configuration option to trigger an alternative button entity (e.g., a hardware button or a button template helper) in parallel with the climate device power-on sequence.