### PR TITLE
2026.6.4

### DIFF
--- a/custom_components/tuya_smart_ir_ac/__init__.py
+++ b/custom_components/tuya_smart_ir_ac/__init__.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import voluptuous as vol
+from datetime import timedelta
 import homeassistant.helpers.config_validation as cv
 from homeassistant.core import HomeAssistant
 from homeassistant.components import persistent_notification
@@ -22,14 +23,17 @@ from .const import (
     CONF_TUYA_COUNTRY,
     CONF_CLIMATE_UPDATE_INTERVAL,
     CONF_SENSOR_UPDATE_INTERVAL,
+    CONF_GLOBAL_PRESETS,
     UPDATE_INTERVAL,
     TUYA_API_ENDPOINTS,
     TUYA_PULSAR_ENDPOINTS,
     DEFAULT_ENABLE_PULSAR,
+    DEFAULT_GLOBAL_PRESETS,
     DEVICE_TYPE_CLIMATES,
     DEVICE_TYPE_SENSORS,
     DEVICE_TYPE_GENERICS
 )
+from .helpers import merge_presets_with_defaults
 from .coordinator import TuyaClimateCoordinator, TuyaSensorCoordinator
 from .manager import TuyaIRManager
 from .models import HubConfigEntry, RuntimeData
@@ -132,12 +136,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: HubConfigEntry) -> bool:
             hass.async_create_task(async_check_pulsar_connection(hass, entry, pulsar_client))
 
         # Save Runtime Data
+        runtime_presets = merge_presets_with_defaults(
+            saved_presets=entry.options.get(CONF_GLOBAL_PRESETS, {}),
+            defaults=DEFAULT_GLOBAL_PRESETS
+        )
+
         entry.runtime_data = RuntimeData(
             api_client=api_client,
             pulsar_client=pulsar_client,
             climate_coordinator=climate_coordinator,
             sensor_coordinator=sensor_coordinator,
-            ir_manager=TuyaIRManager(hass, entry, api_client)
+            ir_manager=TuyaIRManager(hass, entry, api_client),
+            global_presets=runtime_presets
         )
 
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -145,15 +155,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: HubConfigEntry) -> bool:
         _LOGGER.error("[%s] Error during Hub initialization, cleaning up sessions: %s", entry.title, ex)
 
         try:
-            await api_client.close()
+            if api_client:
+                await api_client.close()
         except Exception as api_err:
             _LOGGER.debug("[%s] Failed to close Tuya API client during abort: %s", entry.title, api_err)
 
-        if enable_pulsar:
-            try:
+        try:
+            if pulsar_client:
                 await pulsar_client.stop()
-            except Exception as pulsar_err:
-                _LOGGER.debug("[%s] Failed to stop Tuya Pulsar client during abort: %s", entry.title, pulsar_err)
+        except Exception as pulsar_err:
+            _LOGGER.debug("[%s] Failed to stop Tuya Pulsar client during abort: %s", entry.title, pulsar_err)
 
         raise
 
@@ -162,33 +173,74 @@ async def async_setup_entry(hass: HomeAssistant, entry: HubConfigEntry) -> bool:
     return True
 
 
+async def async_update_entry(hass: HomeAssistant, entry: HubConfigEntry) -> None:
+    """Handles updating options without destroying API sessions."""
+    _LOGGER.debug("[%s] Updating entry in progress...", entry.title)
+    
+    current_data = entry.runtime_data
+
+    new_secret = entry.data.get(CONF_ACCESS_SECRET, "")
+    expected_secret_bytes = new_secret.encode("utf-8")
+
+    new_country = entry.data.get(CONF_TUYA_COUNTRY, "")
+    expected_endpoint = TUYA_API_ENDPOINTS.get(new_country, "")
+
+    expected_climate_interval = timedelta(seconds=entry.data.get(CONF_CLIMATE_UPDATE_INTERVAL, UPDATE_INTERVAL))
+    expected_sensor_interval = timedelta(seconds=entry.data.get(CONF_SENSOR_UPDATE_INTERVAL, UPDATE_INTERVAL))
+
+    expected_enable_pulsar = entry.data.get(CONF_ENABLE_PULSAR, DEFAULT_ENABLE_PULSAR)
+
+    hub_changed = (
+        expected_secret_bytes != current_data.api_client.access_secret_bytes or
+        expected_endpoint != current_data.api_client.endpoint or
+        expected_climate_interval != current_data.climate_coordinator.update_interval or
+        expected_sensor_interval != current_data.sensor_coordinator.update_interval or
+        expected_enable_pulsar != (current_data.pulsar_client is not None)
+    )
+    
+    if hub_changed:
+        _LOGGER.debug("[%s] Tuya Hub modification detected. Force a full reboot.", entry.title)
+        await hass.config_entries.async_reload(entry.entry_id)
+        return
+
+    if entry.disabled_by is None:
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        for device_entry in devices:
+            device_registry.async_remove_device(device_entry.id)
+
+    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    runtime_presets = merge_presets_with_defaults(
+        saved_presets=entry.options.get(CONF_GLOBAL_PRESETS, {}),
+        defaults=DEFAULT_GLOBAL_PRESETS
+    )
+
+    entry.runtime_data = RuntimeData(
+        api_client=current_data.api_client,       
+        pulsar_client=current_data.pulsar_client, 
+        climate_coordinator=current_data.climate_coordinator,
+        sensor_coordinator=current_data.sensor_coordinator,
+        ir_manager=current_data.ir_manager,
+        global_presets=runtime_presets
+    )
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
 async def async_unload_entry(hass: HomeAssistant, entry: HubConfigEntry) -> bool:
     """Unload a config entry and clean up active cloud sessions."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    
-    if unload_ok:
-        if entry.runtime_data:
-            if entry.runtime_data.api_client:
-                _LOGGER.debug("[%s] Closing Tuya API client session during unload.", entry.title)
-                await entry.runtime_data.api_client.close()
-            
-            if entry.runtime_data.pulsar_client:
-                _LOGGER.debug("[%s] Stopping Tuya Pulsar client session during unload.", entry.title)
-                await entry.runtime_data.pulsar_client.stop() 
 
-        if entry.disabled_by is None:
-            device_registry = dr.async_get(hass)
-            devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-            for device_entry in devices:
-                device_registry.async_remove_device(device_entry.id)
+    if unload_ok and entry.runtime_data:
+        if entry.runtime_data.api_client:
+            _LOGGER.debug("[%s] Closing Tuya API client session during unload.", entry.title)
+            await entry.runtime_data.api_client.close()
+
+        if entry.runtime_data.pulsar_client:
+            _LOGGER.debug("[%s] Stopping Tuya Pulsar client session during unload.", entry.title)
+            await entry.runtime_data.pulsar_client.stop() 
 
     return unload_ok
-
-
-async def async_update_entry(hass: HomeAssistant, entry: HubConfigEntry) -> None:
-    """Handle options update by reloading the entry integration flow."""
-    await hass.config_entries.async_reload(entry.entry_id)
-
 
 async def _async_migrate_old_entries(hass: HomeAssistant, hub_entry: HubConfigEntry) -> None:
     """Migrate legacy independent device config entries into centralized Hub options dictionary."""

--- a/custom_components/tuya_smart_ir_ac/climate.py
+++ b/custom_components/tuya_smart_ir_ac/climate.py
@@ -5,6 +5,7 @@ from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     ClimateEntityFeature,
     HVACMode,
+    PRESET_NONE
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -59,12 +60,22 @@ class TuyaClimate(ClimateEntity, CoordinatorEntity, TuyaClimateEntity):
         self._attr_target_temperature_step = self._temp_step
         self._attr_hvac_modes = self._hvac_modes
         self._attr_fan_modes = self._fan_modes
-        self._attr_supported_features = (
+        self._attr_preset_modes = self._preset_modes
+
+    @property
+    def supported_features(self) -> ClimateEntityFeature:
+        """Return the list of supported features dynamically."""
+        features = (
             ClimateEntityFeature.TURN_OFF 
             | ClimateEntityFeature.TURN_ON 
             | ClimateEntityFeature.TARGET_TEMPERATURE 
             | ClimateEntityFeature.FAN_MODE
         )
+        
+        if self._preset_modes:
+            features |= ClimateEntityFeature.PRESET_MODE
+            
+        return features
 
     @property
     def current_temperature(self) -> float | None:
@@ -91,6 +102,29 @@ class TuyaClimate(ClimateEntity, CoordinatorEntity, TuyaClimateEntity):
         """Return the fan setting."""
         return self._current_fan_mode
 
+    @property
+    def preset_modes(self) -> list[str] | None:
+        """Return the list of available preset modes based on current HVAC mode."""
+        global_presets = self._runtime_data.global_presets
+
+        if not global_presets or not self._preset_modes:
+            return None
+
+        current_mode = self._last_hvac_mode
+        available_presets = [PRESET_NONE]
+
+        for preset_name in self._preset_modes:
+            hvac_configs = global_presets.get(preset_name)
+            if hvac_configs and current_mode in hvac_configs:
+                available_presets.append(preset_name)
+
+        return available_presets
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode."""
+        return self._current_preset_mode
+
     async def async_added_to_hass(self) -> None:
         """Restore previous entity state and track source sensors."""
         await super().async_added_to_hass()
@@ -99,6 +133,7 @@ class TuyaClimate(ClimateEntity, CoordinatorEntity, TuyaClimateEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle state changes notified by the Hub coordinator."""
+        self.update_preset_mode_from_state()
         self.async_write_ha_state()
 
     @callback
@@ -132,3 +167,8 @@ class TuyaClimate(ClimateEntity, CoordinatorEntity, TuyaClimateEntity):
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set fan mode for the climate."""
         await self.async_handle_set_fan_mode(fan_mode)
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set preset mode for the climate."""
+        await self.async_handle_set_preset_mode(preset_mode)
+        self.async_write_ha_state()

--- a/custom_components/tuya_smart_ir_ac/climate.py
+++ b/custom_components/tuya_smart_ir_ac/climate.py
@@ -123,7 +123,7 @@ class TuyaClimate(ClimateEntity, CoordinatorEntity, TuyaClimateEntity):
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
-        return self._current_preset_mode
+        return self.get_preset_mode()
 
     async def async_added_to_hass(self) -> None:
         """Restore previous entity state and track source sensors."""
@@ -133,7 +133,6 @@ class TuyaClimate(ClimateEntity, CoordinatorEntity, TuyaClimateEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle state changes notified by the Hub coordinator."""
-        self.update_preset_mode_from_state()
         self.async_write_ha_state()
 
     @callback

--- a/custom_components/tuya_smart_ir_ac/climate.py
+++ b/custom_components/tuya_smart_ir_ac/climate.py
@@ -105,20 +105,7 @@ class TuyaClimate(ClimateEntity, CoordinatorEntity, TuyaClimateEntity):
     @property
     def preset_modes(self) -> list[str] | None:
         """Return the list of available preset modes based on current HVAC mode."""
-        global_presets = self._runtime_data.global_presets
-
-        if not global_presets or not self._preset_modes:
-            return None
-
-        current_mode = self._last_hvac_mode
-        available_presets = [PRESET_NONE]
-
-        for preset_name in self._preset_modes:
-            hvac_configs = global_presets.get(preset_name)
-            if hvac_configs and current_mode in hvac_configs:
-                available_presets.append(preset_name)
-
-        return available_presets
+        return self.get_preset_modes()
 
     @property
     def preset_mode(self) -> str | None:
@@ -129,10 +116,12 @@ class TuyaClimate(ClimateEntity, CoordinatorEntity, TuyaClimateEntity):
         """Restore previous entity state and track source sensors."""
         await super().async_added_to_hass()
         self.async_track_sensor_states([self._temperature_sensor, self._humidity_sensor])
+        self.update_preset_history()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle state changes notified by the Hub coordinator."""
+        self.update_preset_history()
         self.async_write_ha_state()
 
     @callback

--- a/custom_components/tuya_smart_ir_ac/config_flow.py
+++ b/custom_components/tuya_smart_ir_ac/config_flow.py
@@ -9,6 +9,14 @@ from homeassistant.components.sensor.const import SensorDeviceClass
 from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.components.climate.const import (
+    FAN_AUTO,
+    FAN_HIGH,
+    FAN_LOW,
+    FAN_MEDIUM,
+    HVACMode,
+    PRESET_NONE,
+)
 from homeassistant.helpers.selector import (
     BooleanSelector,
     EntitySelector,
@@ -38,12 +46,14 @@ from .const import (
     CONF_ENABLE_PULSAR,
     CONF_FAN_MODES,
     CONF_FAN_POWER_ON,
+    CONF_GLOBAL_PRESETS,
     CONF_HUMIDITY_SENSOR,
     CONF_HVAC_MODES,
     CONF_HVAC_POWER_ON,
     CONF_HVAC_PRESETS,
     CONF_INFRARED_ID,
     CONF_OPTIONAL_ENTITIES,
+    CONF_PRESET_MODES,
     CONF_SENSOR_TYPES,
     CONF_SENSOR_UPDATE_INTERVAL,
     CONF_TEMPERATURE_SENSOR,
@@ -53,14 +63,17 @@ from .const import (
     CONF_TEMP_STEP,
     CONF_TEMP_UNIT,
     CONF_TUYA_COUNTRY,
+    DEFAULT_FAN_MODE,
     DEFAULT_DRY_MIN_FAN,
     DEFAULT_DRY_MIN_TEMP,
     DEFAULT_ENABLE_PULSAR,
     DEFAULT_FAN_POWER_ON,
+    DEFAULT_GLOBAL_PRESETS,
     DEFAULT_HVAC_POWER_ON,
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_TEMP,
     DEFAULT_PRECISION,
+    DEFAULT_TEMPERATURE,
     DEFAULT_TEMP_POWER_ON,
     DEVICE_TYPE_CLIMATES,
     DEVICE_TYPE_GENERICS,
@@ -74,6 +87,14 @@ from .const import (
     SUPPORTED_HVAC_PRESETS,
     SUPPORTED_OPTIONAL_ENTITIES,
     SUPPORTED_POWER_ON_MODES,
+    SUPPORTED_PRESET_MODES,
+    TRANSLATION_KEY_COUNTRIES,
+    TRANSLATION_KEY_FAN_MODES,
+    TRANSLATION_KEY_HVAC_MODES,
+    TRANSLATION_KEY_HVAC_PRESETS,
+    TRANSLATION_KEY_OPTIONAL_ENTITIES,
+    TRANSLATION_KEY_POWER_ON_MODES,
+    TRANSLATION_KEY_PRESET_MODES,
     TUYA_API_ENDPOINTS,
     UPDATE_INTERVAL,
 )
@@ -81,6 +102,7 @@ from .models import (
     TuyaSensorData,
     TuyaAPIResult
 )
+from .helpers import merge_presets_with_defaults
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -188,57 +210,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self._next_action = None
         return self.async_show_menu(
             step_id="init",
-            menu_options=["device_management", "hub_settings"]
+            menu_options=["device_management", "presets_management",  "hub_settings"]
         )
-
-    async def async_step_device_management(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Display sub-menu filtering specific device category platforms."""
-        return self.async_show_menu(
-            step_id="device_management",
-            menu_options=["climate_management", "generic_management", "sensor_management", "back_to_init"]
-        )
-        
-    async def async_step_back_to_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Route the user backward to the core root entry menu."""
-        return await self.async_step_init()
-
-    async def async_step_climate_management(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Display management sub-menu for dynamic HVAC air conditioners."""
-        return self.async_show_menu(
-            step_id="climate_management",
-            menu_options=["add_climate", "edit_climate", "remove_climate", "back_to_devices"]
-        )
-        
-    async def async_step_generic_management(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Display management sub-menu for IR generic remotes."""
-        return self.async_show_menu(
-            step_id="generic_management",
-            menu_options=["add_generic", "remove_generic", "back_to_devices"]
-        )
-        
-    async def async_step_sensor_management(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Display management sub-menu for TH environmental hardware sensors."""
-        return self.async_show_menu(
-            step_id="sensor_management",
-            menu_options=["add_sensor", "remove_sensor", "back_to_devices"]
-        )
-
-    async def async_step_back_to_devices(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Route the user backward to the device category selection menu."""
-        return await self.async_step_device_management()
-
+    
     async def async_step_hub_settings(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -276,6 +250,38 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             step_id="hub_settings",
             data_schema=schema,
             errors=errors
+        )
+
+    async def async_step_device_management(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Display sub-menu filtering specific device category platforms."""
+        return self.async_show_menu(
+            step_id="device_management",
+            menu_options=["climate_management", "generic_management", "sensor_management", "back_to_init"]
+        )
+    
+    async def async_step_back_to_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Route the user backward to the core root entry menu."""
+        return await self.async_step_init()
+
+    async def async_step_back_to_devices(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Route the user backward to the device category selection menu."""
+        return await self.async_step_device_management()
+
+    # Climate device management flows
+
+    async def async_step_climate_management(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Display management sub-menu for dynamic HVAC air conditioners."""
+        return self.async_show_menu(
+            step_id="climate_management",
+            menu_options=["add_climate", "edit_climate", "remove_climate", "back_to_devices"]
         )
 
     async def async_step_add_climate(
@@ -355,7 +361,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             )
 
         schema = self.add_suggested_values_to_schema(
-            vol.Schema(climate_data()), climates[index]
+            vol.Schema(climate_data()), prepare_suggested_values(climates[index])
         )
 
         return self.async_show_form(
@@ -400,6 +406,130 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema({vol.Required("climate_id"): vol.In(options)})
         )
     
+    # Climate preset management flows
+    
+    async def async_step_presets_management(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Global preset selection preset and mode."""
+        if user_input is not None:
+            return await self.async_step_preset_configure(user_input)
+
+        available_presets = list(DEFAULT_GLOBAL_PRESETS.keys())
+        available_hvac_modes = list({
+            mode 
+            for preset_configs in DEFAULT_GLOBAL_PRESETS.values() 
+            for mode in preset_configs.keys()
+        })
+
+        return self.async_show_form(
+            step_id="presets_management",
+            last_step=False,
+            data_schema=vol.Schema({
+                vol.Required("preset"): SelectSelector(
+                    SelectSelectorConfig(
+                        options=available_presets,
+                        mode=SelectSelectorMode.DROPDOWN,
+                        translation_key=TRANSLATION_KEY_PRESET_MODES
+                    )
+                ),
+                vol.Required("hvac_mode"): SelectSelector(
+                    SelectSelectorConfig(
+                        options=available_hvac_modes,
+                        mode=SelectSelectorMode.DROPDOWN,
+                        translation_key=TRANSLATION_KEY_HVAC_MODES
+                    )
+                ),
+            })
+        )
+
+    async def async_step_preset_configure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Global preset setup and save."""
+        
+        preset_data = dict(self.config_entry.options.get(CONF_GLOBAL_PRESETS, {}))
+
+        if user_input is not None and "temp" in user_input:
+            preset = user_input["preset"]
+            mode = user_input["hvac_mode"]
+            
+            if preset not in preset_data:
+                preset_data[preset] = {}
+            
+            preset_data[preset][mode] = {
+                "temp": user_input["temp"],
+                "fan": user_input["fan"]
+            }
+            
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, 
+                options={**self.config_entry.options, CONF_GLOBAL_PRESETS: preset_data}
+            )
+            
+            if self.config_entry.runtime_data:
+                updated_presets = merge_presets_with_defaults(
+                    saved_presets=preset_data,
+                    defaults=DEFAULT_GLOBAL_PRESETS
+                )
+                self.config_entry.runtime_data.global_presets.clear()
+                self.config_entry.runtime_data.global_presets.update(updated_presets)
+                
+            return await self.async_step_init()
+
+        preset = user_input.get("preset") if user_input else ""
+        mode = user_input.get("hvac_mode") if user_input else ""
+        
+        default_conf = DEFAULT_GLOBAL_PRESETS.get(preset, {}).get(mode, {})
+        current_conf = preset_data.get(preset, {}).get(mode, default_conf)
+
+        return self.async_show_form(
+            step_id="preset_configure",
+            data_schema=vol.Schema({
+                vol.Required("preset", default=preset): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[preset], 
+                        mode=SelectSelectorMode.DROPDOWN,
+                        translation_key=TRANSLATION_KEY_PRESET_MODES
+                    )
+                ),
+                vol.Required("hvac_mode", default=mode): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[mode],
+                        mode=SelectSelectorMode.DROPDOWN,
+                        translation_key=TRANSLATION_KEY_HVAC_MODES
+                    )
+                ),
+                vol.Required("temp", default=current_conf.get("temp", DEFAULT_TEMPERATURE)): NumberSelector(
+                    NumberSelectorConfig(
+                        min=DEFAULT_MIN_TEMP,
+                        max=DEFAULT_MAX_TEMP,
+                        step=1,
+                        mode=NumberSelectorMode.SLIDER
+                    )
+                ),
+                vol.Required("fan", default=current_conf.get("fan", DEFAULT_FAN_MODE)): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[FAN_AUTO, FAN_LOW, FAN_MEDIUM, FAN_HIGH],
+                        mode=SelectSelectorMode.DROPDOWN,
+                        translation_key=TRANSLATION_KEY_FAN_MODES
+                    )
+                ),
+            })
+        )
+
+
+    # Generic device management flows
+
+    async def async_step_generic_management(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Display management sub-menu for IR generic remotes."""
+        return self.async_show_menu(
+            step_id="generic_management",
+            menu_options=["add_generic", "remove_generic", "back_to_devices"]
+        )
+
     async def async_step_add_generic(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -492,6 +622,17 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="select_generic",
             data_schema=vol.Schema({vol.Required("generic_id"): vol.In(options)})
+        )
+
+    # Temperature/Humidy sensor management flows
+
+    async def async_step_sensor_management(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Display management sub-menu for TH environmental hardware sensors."""
+        return self.async_show_menu(
+            step_id="sensor_management",
+            menu_options=["add_sensor", "remove_sensor", "back_to_devices"]
         )
 
     async def async_step_add_sensor(
@@ -627,14 +768,14 @@ def hub_data_schema() -> dict[vol.Marker, Any]:
             TextSelectorConfig(type=TextSelectorType.TEXT)
         ),
         vol.Required(CONF_ACCESS_SECRET): TextSelector(
-            TextSelectorConfig(type=TextSelectorType.TEXT)
+            TextSelectorConfig(type=TextSelectorType.PASSWORD)
         ),
         vol.Required(CONF_TUYA_COUNTRY): SelectSelector(
             SelectSelectorConfig(
                 options=list(TUYA_API_ENDPOINTS.keys()),
                 multiple=False,
                 mode=SelectSelectorMode.DROPDOWN,
-                translation_key=CONF_TUYA_COUNTRY
+                translation_key=TRANSLATION_KEY_COUNTRIES
             )
         ),
         vol.Required(CONF_CLIMATE_UPDATE_INTERVAL, default=UPDATE_INTERVAL): NumberSelector(
@@ -713,12 +854,12 @@ def climate_data() -> dict[vol.Marker, Any]:
                 min=0.1, max=1, step=0.1, mode=NumberSelectorMode.BOX
             )
         ),
-        vol.Required(CONF_HVAC_MODES, default=SUPPORTED_HVAC_MODES): SelectSelector(
+        vol.Required(CONF_HVAC_MODES, default=[m for m in SUPPORTED_HVAC_MODES if m != HVACMode.OFF]): SelectSelector(
             SelectSelectorConfig(
-                options=SUPPORTED_HVAC_MODES,
+                options=[mode for mode in SUPPORTED_HVAC_MODES if mode != HVACMode.OFF],
                 multiple=True,
                 mode=SelectSelectorMode.DROPDOWN,
-                translation_key=CONF_HVAC_MODES,
+                translation_key=TRANSLATION_KEY_HVAC_MODES,
             )
         ),
         vol.Required(CONF_FAN_MODES, default=SUPPORTED_FAN_MODES): SelectSelector(
@@ -726,7 +867,15 @@ def climate_data() -> dict[vol.Marker, Any]:
                 options=SUPPORTED_FAN_MODES,
                 multiple=True,
                 mode=SelectSelectorMode.DROPDOWN,
-                translation_key=CONF_FAN_MODES,
+                translation_key=TRANSLATION_KEY_FAN_MODES,
+            )
+        ),
+        vol.Required(CONF_PRESET_MODES, default=[]): SelectSelector(
+            SelectSelectorConfig(
+                options=[mode for mode in SUPPORTED_PRESET_MODES if mode != PRESET_NONE],
+                multiple=True,
+                mode=SelectSelectorMode.DROPDOWN,
+                translation_key=TRANSLATION_KEY_PRESET_MODES,
             )
         ),
         vol.Optional(CONF_HVAC_PRESETS, default=[]): SelectSelector(
@@ -734,7 +883,7 @@ def climate_data() -> dict[vol.Marker, Any]:
                 options=SUPPORTED_HVAC_PRESETS,
                 multiple=True,
                 mode=SelectSelectorMode.DROPDOWN,
-                translation_key=CONF_HVAC_PRESETS,
+                translation_key=TRANSLATION_KEY_HVAC_PRESETS,
             )
         ),
         vol.Optional(CONF_OPTIONAL_ENTITIES, default=[]): SelectSelector(
@@ -742,7 +891,7 @@ def climate_data() -> dict[vol.Marker, Any]:
                 options=SUPPORTED_OPTIONAL_ENTITIES,
                 multiple=True,
                 mode=SelectSelectorMode.DROPDOWN,
-                translation_key=CONF_OPTIONAL_ENTITIES,
+                translation_key=TRANSLATION_KEY_OPTIONAL_ENTITIES,
             )
         ),
         vol.Required(CONF_COMPATIBILITY_OPTIONS): data_entry_flow.section(
@@ -755,7 +904,7 @@ def climate_data() -> dict[vol.Marker, Any]:
                             options=SUPPORTED_POWER_ON_MODES,
                             multiple=False,
                             mode=SelectSelectorMode.LIST,
-                            translation_key=CONF_HVAC_POWER_ON,
+                            translation_key=TRANSLATION_KEY_POWER_ON_MODES,
                         )
                     ),
                     vol.Optional(
@@ -765,7 +914,7 @@ def climate_data() -> dict[vol.Marker, Any]:
                             options=SUPPORTED_POWER_ON_MODES,
                             multiple=False,
                             mode=SelectSelectorMode.LIST,
-                            translation_key=CONF_TEMP_POWER_ON,
+                            translation_key=TRANSLATION_KEY_POWER_ON_MODES,
                         )
                     ),
                     vol.Optional(
@@ -775,7 +924,7 @@ def climate_data() -> dict[vol.Marker, Any]:
                             options=SUPPORTED_POWER_ON_MODES,
                             multiple=False,
                             mode=SelectSelectorMode.LIST,
-                            translation_key=CONF_FAN_POWER_ON,
+                            translation_key=TRANSLATION_KEY_POWER_ON_MODES,
                         )
                     ),
                     vol.Optional(
@@ -796,25 +945,32 @@ def climate_data() -> dict[vol.Marker, Any]:
         ),
     }
 
-
 async def async_validate_and_connect(data: dict[str, Any]) -> dict[str, str]:
-    """Validate credentials against the Tuya OpenAPI backend."""
     errors: dict[str, str] = {}
-    
+
     api_endpoint = TUYA_API_ENDPOINTS.get(data.get(CONF_TUYA_COUNTRY))
     client = TuyaOpenAPI(api_endpoint, data[CONF_ACCESS_ID], data[CONF_ACCESS_SECRET])
-    
+
     try:
         res = await client.connect()
         if not res.get("success"):
-            errors["base"] = "invalid_auth"
-            _LOGGER.debug("Tuya authentication failed: %s", res.get("msg"))
+           errors["base"] = "invalid_auth"
+           _LOGGER.debug("Tuya authentication failed: %s", res.get("msg"))
+        else:
+            uid = res.get("result", {}).get("uid")
+            user_info = await client.get(f"/v1.0/users/{uid}/infos")
+            
+            if user_info.get("code") == 28841107:
+                errors["base"] = "invalid_data_center"
+                _LOGGER.debug("Tuya authentication failed: %s", user_info.get("msg"))
+
     except Exception as err:
         errors["base"] = "cannot_connect_to_tuya"
         _LOGGER.debug("Unexpected error connecting to Tuya API: %s", err)
+
     finally:
         await client.close()
-            
+
     return errors
 
 async def async_get_climate_device(
@@ -838,12 +994,41 @@ async def async_get_sensor_device(
     return await TuyaSensorAPI(hass, client).async_fetch_data(device_id)
 
 
+def prepare_suggested_values(climate_data: dict[str, Any]) -> dict[str, Any]:
+    """Strip mandatory system modes (OFF/NONE) from stored data before showing the UI form."""
+    suggested_data = dict(climate_data)
+    if CONF_HVAC_MODES in suggested_data and suggested_data[CONF_HVAC_MODES]:
+        suggested_data[CONF_HVAC_MODES] = [
+            m for m in suggested_data[CONF_HVAC_MODES] if m != HVACMode.OFF
+        ]
+
+    if CONF_PRESET_MODES in suggested_data and suggested_data[CONF_PRESET_MODES]:
+        suggested_data[CONF_PRESET_MODES] = [
+            p for p in suggested_data[CONF_PRESET_MODES] if p != PRESET_NONE
+        ]
+
+    return suggested_data
+
+
 def overwrite_invalid_user_input(user_input: dict[str, Any]) -> None:
     """Enforce fallback lists matching integration defaults on empty arrays."""
     hvac_modes = user_input.get(CONF_HVAC_MODES)
-    if hvac_modes is not None and len(hvac_modes) == 0:
-        user_input[CONF_HVAC_MODES] = SUPPORTED_HVAC_MODES
+    if hvac_modes is not None:
+        if len(hvac_modes) == 0:
+            user_input[CONF_HVAC_MODES] = SUPPORTED_HVAC_MODES
+        elif HVACMode.OFF not in hvac_modes:
+            updated_hvac = list(hvac_modes)
+            updated_hvac.insert(0, HVACMode.OFF)
+            user_input[CONF_HVAC_MODES] = updated_hvac
 
     fan_modes = user_input.get(CONF_FAN_MODES)
     if fan_modes is not None and len(fan_modes) == 0:
         user_input[CONF_FAN_MODES] = SUPPORTED_FAN_MODES
+
+    preset_modes = user_input.get(CONF_PRESET_MODES)
+    if preset_modes is not None:
+        if len(preset_modes) > 0 and PRESET_NONE not in preset_modes:
+            updated_presets = list(preset_modes)
+            updated_presets.insert(0, PRESET_NONE)
+            user_input[CONF_PRESET_MODES] = updated_presets
+

--- a/custom_components/tuya_smart_ir_ac/const.py
+++ b/custom_components/tuya_smart_ir_ac/const.py
@@ -5,6 +5,14 @@ from homeassistant.components.climate import (
     FAN_MEDIUM,
     HVACMode,
 )
+from homeassistant.components.climate.const import (
+    PRESET_NONE,
+    PRESET_HOME,
+    PRESET_SLEEP,
+    PRESET_ECO,
+    PRESET_COMFORT,
+    PRESET_AWAY,
+)
 from homeassistant.const import Platform, UnitOfTemperature
 
 # Core Integration Setup
@@ -13,6 +21,7 @@ MANUFACTURER = "Tuya"
 CLIMATE_MODEL = "IR Air Conditioning"
 GENERIC_MODEL = "IR Remote Control"
 SENSOR_MODEL = "T & H Sensor"
+TEST_MODE = True
 
 # Platforms supported by this integration
 PLATFORMS = [
@@ -58,7 +67,9 @@ CONF_TEMP_MAX = "max_temp"
 CONF_TEMP_STEP = "temp_step"
 CONF_HVAC_MODES = "hvac_modes"
 CONF_FAN_MODES = "fan_modes"
+CONF_PRESET_MODES = "preset_modes"
 CONF_HVAC_PRESETS = "hvac_presets"
+CONF_GLOBAL_PRESETS = "global_presets"
 CONF_OPTIONAL_ENTITIES = "optional_entities"
 CONF_COMPATIBILITY_OPTIONS = "compatibility_options"
 CONF_HVAC_POWER_ON = "hvac_power_on"
@@ -102,6 +113,28 @@ DEFAULT_CURRENT_TEMPERATURE = 0.0
 DEFAULT_CURRENT_HUMIDITY = 0
 DEFAULT_BATTERY_STATE = "middle"
 
+DEFAULT_GLOBAL_PRESETS = {
+    PRESET_HOME: {
+        HVACMode.COOL: {"temp": 26.0, "fan": FAN_AUTO},
+        HVACMode.HEAT: {"temp": 21.0, "fan": FAN_AUTO}
+    },
+    PRESET_SLEEP: {
+        HVACMode.COOL: {"temp": 27.0, "fan": FAN_LOW},
+        HVACMode.HEAT: {"temp": 20.0, "fan": FAN_LOW}
+    },
+    PRESET_ECO: {
+        HVACMode.COOL: {"temp": 27.0, "fan": FAN_MEDIUM},
+        HVACMode.HEAT: {"temp": 20.0, "fan": FAN_MEDIUM}
+    },
+    PRESET_COMFORT: {
+        HVACMode.COOL: {"temp": 25.0, "fan": FAN_MEDIUM},
+        HVACMode.HEAT: {"temp": 22.0, "fan": FAN_MEDIUM}
+    },
+    PRESET_AWAY: {
+        HVACMode.COOL: {"temp": 28.0, "fan": FAN_LOW},
+        HVACMode.HEAT: {"temp": 19.0, "fan": FAN_LOW}
+    }
+}
 
 # Frontend Selection/Validation Lists
 SUPPORTED_POWER_ON_MODES = [
@@ -126,6 +159,15 @@ SUPPORTED_FAN_MODES = [
     FAN_HIGH,
 ]
 
+SUPPORTED_PRESET_MODES = [
+    PRESET_NONE,
+    PRESET_HOME,
+    PRESET_SLEEP,
+    PRESET_ECO,
+    PRESET_COMFORT,    
+    PRESET_AWAY,
+]
+
 SUPPORTED_HVAC_PRESETS = [
     PRESET_TEMP_HVAC_MODE,
     PRESET_FAN_HVAC_MODE,
@@ -144,6 +186,19 @@ SUPPORTED_OPTIONAL_ENTITIES = [
     ENTITY_CURRENT_TEMPERATURE,
     ENTITY_CURRENT_HUMIDITY,
 ]
+
+# Translation keys
+TRANSLATION_KEY_HVAC_MODE = "hvac_mode"
+TRANSLATION_KEY_FAN_MODE = "fan_mode"
+TRANSLATION_KEY_TEMPERATURE = "temperature"
+TRANSLATION_KEY_HVAC_MODES = "hvac_modes"
+TRANSLATION_KEY_FAN_MODES = "fan_modes"
+TRANSLATION_KEY_PRESET_MODES = "presets_modes"
+TRANSLATION_KEY_COUNTRIES = "countries"
+TRANSLATION_KEY_HVAC_PRESETS = "hvac_presets"
+TRANSLATION_KEY_OPTIONAL_ENTITIES = "optional_entities"
+TRANSLATION_KEY_POWER_ON_MODES = "power_on_modes"
+
 
 # Tuya API Mappings
 BATTERY_LEVELS = {

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -114,7 +114,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         await self._async_force_update_data(climate_id, power=True, fan_mode=fan_mode)
 
     # =========================================================================
-    # PRIVATE LOW-LEVEL COMMAND HELPERS (DRY ENFORCEMENT)
+    # PRIVATE LOW-LEVEL COMMAND HELPERS
     # =========================================================================
 
     async def _send_power_command(self, infrared_id: str, climate_id: str, state: str) -> None:

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -103,8 +103,6 @@ class TuyaClimateEntity:
             model=CLIMATE_MODEL,
         )
         self._temperature_unit = UnitOfTemperature.CELSIUS
-        self._current_preset_mode = PRESET_NONE
-
 
     @property
     def available(self) -> bool:
@@ -259,22 +257,17 @@ class TuyaClimateEntity:
 
         return convert_to_float(sensor_state.state)
 
-    def update_preset_mode_from_state(self) -> None:
-        """Calculate and update the active preset matching real-time device configurations."""
-        data = self._device_climate_data
-        if not data or data.temperature is None or not data.fan_mode:
-            return
-        
+    def get_preset_mode(self) -> str:
+        """Calculate and update the active preset matching real-time device configurations."""        
         for preset_name, mode_configs in self._runtime_data.global_presets.items():
             if self._last_hvac_mode not in mode_configs:
                 continue
 
             if mode_config := mode_configs.get(self._last_hvac_mode):
                 if mode_config.get("temp") == self._current_target_temperature and mode_config.get("fan") == self._current_fan_mode:
-                    self._current_preset_mode = preset_name
-                    return
+                    return preset_name
 
-        self._current_preset_mode = PRESET_NONE
+        return PRESET_NONE
 
     # =========================================================================
     # CENTRALIZED SERVICE CALL HANDLERS
@@ -350,7 +343,6 @@ class TuyaClimateEntity:
 
     async def async_handle_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset mode for the climate device."""
-        self._current_preset_mode = preset_mode
         if preset_mode == PRESET_NONE:
             return
 

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
 from homeassistant.components.climate.const import (
     FAN_AUTO,
     FAN_LOW,
+    PRESET_NONE,
     HVACMode,
 )
 from .const import (
@@ -28,6 +29,7 @@ from .const import (
     CONF_TEMP_UNIT,
     CONF_HVAC_MODES,
     CONF_FAN_MODES,
+    CONF_PRESET_MODES,
     CONF_HVAC_PRESETS,
     CONF_COMPATIBILITY_OPTIONS,
     CONF_HVAC_POWER_ON,
@@ -81,6 +83,7 @@ class TuyaClimateEntity:
         self._temp_step = config_data.get(CONF_TEMP_STEP, DEFAULT_PRECISION)
         self._hvac_modes = config_data.get(CONF_HVAC_MODES, SUPPORTED_HVAC_MODES)
         self._fan_modes = config_data.get(CONF_FAN_MODES, SUPPORTED_FAN_MODES)
+        self._preset_modes = config_data.get(CONF_PRESET_MODES, [])
         self._preset_temp_hvac_mode = PRESET_TEMP_HVAC_MODE in config_data.get(CONF_HVAC_PRESETS, [])
         self._preset_fan_hvac_mode = PRESET_FAN_HVAC_MODE in config_data.get(CONF_HVAC_PRESETS, [])
         compatibility = config_data.get(CONF_COMPATIBILITY_OPTIONS, {})
@@ -100,6 +103,8 @@ class TuyaClimateEntity:
             model=CLIMATE_MODEL,
         )
         self._temperature_unit = UnitOfTemperature.CELSIUS
+        self._current_preset_mode = PRESET_NONE
+
 
     @property
     def available(self) -> bool:
@@ -254,6 +259,23 @@ class TuyaClimateEntity:
 
         return convert_to_float(sensor_state.state)
 
+    def update_preset_mode_from_state(self) -> None:
+        """Calculate and update the active preset matching real-time device configurations."""
+        data = self._device_climate_data
+        if not data or data.temperature is None or not data.fan_mode:
+            return
+        
+        for preset_name, mode_configs in self._runtime_data.global_presets.items():
+            if self._last_hvac_mode not in mode_configs:
+                continue
+
+            if mode_config := mode_configs.get(self._last_hvac_mode):
+                if mode_config.get("temp") == self._current_target_temperature and mode_config.get("fan") == self._current_fan_mode:
+                    self._current_preset_mode = preset_name
+                    return
+
+        self._current_preset_mode = PRESET_NONE
+
     # =========================================================================
     # CENTRALIZED SERVICE CALL HANDLERS
     # =========================================================================
@@ -325,6 +347,41 @@ class TuyaClimateEntity:
             await self.coordinator.async_set_fan_mode(
                 self._infrared_id, self._climate_id, fan_mode
             )
+
+    async def async_handle_set_preset_mode(self, preset_mode: str) -> None:
+        """Set preset mode for the climate device."""
+        self._current_preset_mode = preset_mode
+        if preset_mode == PRESET_NONE:
+            return
+
+        if (preset_config := self._runtime_data.global_presets.get(preset_mode)) is not None:
+            target_mode = self._last_hvac_mode
+
+            if target_mode not in preset_config:
+                #_LOGGER.warning(f"Preset '{preset_mode}' is not compatible with current HVAC mode '{target_mode}'. No action will be taken.")
+                return
+
+            mode_config = preset_config.get(target_mode)
+            target_temp = mode_config.get("temp")
+            target_fan = mode_config.get("fan")
+
+            if self.get_hvac_power_on(self._current_hvac_mode):
+                await self._async_trigger_custom_on_if_configured()
+                await self.coordinator.async_turn_on_with_hvac_mode(
+                    self._infrared_id, 
+                    self._climate_id, 
+                    target_mode,
+                    target_temp, 
+                    target_fan
+                )
+            else:
+                await self.coordinator.async_set_hvac_mode(
+                    self._infrared_id, 
+                    self._climate_id, 
+                    target_mode,
+                    target_temp, 
+                    target_fan
+                )
 
     async def _async_trigger_custom_on_if_configured(self) -> None:
         """Trigger the custom hardware alternative power-on button if configured."""

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -103,6 +103,7 @@ class TuyaClimateEntity:
             model=CLIMATE_MODEL,
         )
         self._temperature_unit = UnitOfTemperature.CELSIUS
+        self._last_valid_preset_hvac_mode = None
 
     @property
     def available(self) -> bool:
@@ -121,7 +122,7 @@ class TuyaClimateEntity:
         return TuyaClimateData()
 
     @property
-    def _last_hvac_mode(self) -> HVACMode:
+    def _real_hvac_mode(self) -> HVACMode:
         """Centralized accessor to fetch the current active HVAC mode from the coordinator state."""
         data = self._device_climate_data
         return data.hvac_mode
@@ -168,6 +169,12 @@ class TuyaClimateEntity:
             self.async_on_remove(
                 async_track_state_change_event(self.hass, valid_sensors, self._handle_sensor_state_change)
             )
+
+    def update_preset_history(self) -> None:
+        """Update the history of the last valid HVAC mode supporting presets."""
+        mode = self._real_hvac_mode
+        if mode in (HVACMode.COOL, HVACMode.HEAT):
+            self._last_valid_preset_hvac_mode = mode
 
     # =========================================================================
     # BUSINESS LOGIC HELPER METHODS
@@ -257,13 +264,36 @@ class TuyaClimateEntity:
 
         return convert_to_float(sensor_state.state)
 
+    def get_preset_modes(self) -> str:
+        """Return the list of available preset modes based on current HVAC mode."""    
+        global_presets = self._runtime_data.global_presets
+
+        if not global_presets or not self._preset_modes:
+            return None
+
+        current_mode = self._real_hvac_mode
+        if self._last_valid_preset_hvac_mode and self.hvac_mode is HVACMode.OFF:
+            current_mode = self._last_valid_preset_hvac_mode
+
+        available_presets = [PRESET_NONE]
+
+        for preset_name in self._preset_modes:
+            hvac_configs = global_presets.get(preset_name)
+            if hvac_configs and current_mode in hvac_configs:
+                available_presets.append(preset_name)
+
+        return available_presets
+    
     def get_preset_mode(self) -> str:
-        """Calculate and update the active preset matching real-time device configurations."""        
+        """Return the active preset matching real-time device configurations."""        
+        if self._current_hvac_mode is HVACMode.OFF:
+            return PRESET_NONE
+
         for preset_name, mode_configs in self._runtime_data.global_presets.items():
-            if self._last_hvac_mode not in mode_configs:
+            if self._real_hvac_mode not in mode_configs:
                 continue
 
-            if mode_config := mode_configs.get(self._last_hvac_mode):
+            if mode_config := mode_configs.get(self._real_hvac_mode):
                 if mode_config.get("temp") == self._current_target_temperature and mode_config.get("fan") == self._current_fan_mode:
                     return preset_name
 
@@ -343,14 +373,17 @@ class TuyaClimateEntity:
 
     async def async_handle_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset mode for the climate device."""
+        
         if preset_mode == PRESET_NONE:
             return
 
         if (preset_config := self._runtime_data.global_presets.get(preset_mode)) is not None:
-            target_mode = self._last_hvac_mode
+            target_mode = self._real_hvac_mode
+
+            if self._last_valid_preset_hvac_mode and self._current_hvac_mode is HVACMode.OFF:
+                target_mode = self._last_valid_preset_hvac_mode
 
             if target_mode not in preset_config:
-                #_LOGGER.warning(f"Preset '{preset_mode}' is not compatible with current HVAC mode '{target_mode}'. No action will be taken.")
                 return
 
             mode_config = preset_config.get(target_mode)

--- a/custom_components/tuya_smart_ir_ac/helpers.py
+++ b/custom_components/tuya_smart_ir_ac/helpers.py
@@ -1,5 +1,6 @@
+import copy
 import math
-from typing import Any
+from typing import Any, Dict
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import State
@@ -118,3 +119,20 @@ def normalize_tuya_payload(raw_list: list[dict[str, Any]], mapping: dict[str, st
             normalized_code = mapping.get(raw_code, raw_code)
             normalized_map[normalized_code] = item.get("value")
     return normalized_map
+
+
+def merge_presets_with_defaults(
+    saved_presets: Dict[str, Any], 
+    defaults: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Merge saved presets with defaults."""
+    final_presets = copy.deepcopy(defaults)
+
+    for preset, modes in saved_presets.items():
+        if preset not in final_presets:
+            final_presets[preset] = {}
+        
+        if isinstance(modes, dict):
+            final_presets[preset].update(modes)
+        
+    return final_presets

--- a/custom_components/tuya_smart_ir_ac/manifest.json
+++ b/custom_components/tuya_smart_ir_ac/manifest.json
@@ -8,5 +8,5 @@
    "iot_class": "cloud_polling",
    "issue_tracker": "https://github.com/EnzoD86/tuya-smart-ir-ac/issues",
    "requirements": [],
-   "version": "2026.6.3"
+   "version": "2026.6.4"
 }

--- a/custom_components/tuya_smart_ir_ac/models.py
+++ b/custom_components/tuya_smart_ir_ac/models.py
@@ -49,6 +49,7 @@ class RuntimeData:
     climate_coordinator: TuyaClimateCoordinator | None = None
     sensor_coordinator: TuyaSensorCoordinator | None = None
     ir_manager: TuyaIRManager | None = None
+    global_presets: dict[str, dict[str, Any]] = field(default_factory=dict)
     hvac_presets: dict[str, Any] = field(default_factory=dict)
 
 

--- a/custom_components/tuya_smart_ir_ac/number.py
+++ b/custom_components/tuya_smart_ir_ac/number.py
@@ -20,6 +20,7 @@ from .const import (
     SUPPORTED_TEMP_HVAC_MODES,
     PRESET_TEMP_HVAC_MODE,
     ENTITY_TEMPERATURE_SETPOINT,
+    TRANSLATION_KEY_HVAC_MODE
 )
 from .helpers import (
     valid_number_data,
@@ -76,7 +77,7 @@ class TuyaPresetTemperatureNumber(RestoreNumber, TuyaClimateEntity):
         self._temp_hvac_mode = temp_hvac_mode
 
         self._attr_has_entity_name = True
-        self._attr_translation_key = f"{PRESET_TEMP_HVAC_MODE}_{temp_hvac_mode}"
+        self. _attr_translation_key= f"{TRANSLATION_KEY_HVAC_MODE}_{temp_hvac_mode}"
         self._attr_entity_category = EntityCategory.CONFIG
         self._attr_device_class = NumberDeviceClass.TEMPERATURE
         self._attr_mode = NumberMode.SLIDER
@@ -114,7 +115,6 @@ class TuyaTemperatureSetPointNumber(NumberEntity, CoordinatorEntity, TuyaClimate
         super().__init__(runtime_data.climate_coordinator)
 
         self._attr_has_entity_name = True
-        self._attr_translation_key = f"{ENTITY_TEMPERATURE_SETPOINT}"
         self._attr_device_class = NumberDeviceClass.TEMPERATURE
         self._attr_mode = NumberMode.BOX
         self._attr_native_min_value = self._min_temp

--- a/custom_components/tuya_smart_ir_ac/select.py
+++ b/custom_components/tuya_smart_ir_ac/select.py
@@ -14,7 +14,9 @@ from .const import (
     CONF_OPTIONAL_ENTITIES,
     ENTITY_HVAC_MODE,
     ENTITY_FAN_MODE,
-    PRESET_FAN_HVAC_MODE
+    PRESET_FAN_HVAC_MODE,
+    TRANSLATION_KEY_HVAC_MODE,
+    TRANSLATION_KEY_FAN_MODE,
 )
 from .helpers import valid_sensor_state
 from .entity import TuyaClimateEntity
@@ -66,7 +68,7 @@ class TuyaPresetFanSelect(SelectEntity, RestoreEntity, TuyaClimateEntity):
         TuyaClimateEntity.__init__(self, config_data, runtime_data, PRESET_FAN_HVAC_MODE)
 
         self._attr_has_entity_name = True
-        self._attr_translation_key = f"{PRESET_FAN_HVAC_MODE}"
+        self._attr_translation_key = f"{TRANSLATION_KEY_FAN_MODE}"
         self._attr_entity_category = EntityCategory.CONFIG
         self._attr_icon = "mdi:fan"
         self._attr_options = self._fan_modes
@@ -99,7 +101,7 @@ class TuyaHvacModeSelect(SelectEntity, CoordinatorEntity, TuyaClimateEntity):
         super().__init__(runtime_data.climate_coordinator)
 
         self._attr_has_entity_name = True
-        self._attr_translation_key = f"{ENTITY_HVAC_MODE}"
+        self._attr_translation_key = f"{TRANSLATION_KEY_HVAC_MODE}"
         self._attr_icon = "mdi:hvac"
         self._attr_options = self._hvac_modes
 
@@ -122,7 +124,7 @@ class TuyaFanModeSelect(SelectEntity, CoordinatorEntity, TuyaClimateEntity):
         super().__init__(runtime_data.climate_coordinator)
 
         self._attr_has_entity_name = True
-        self._attr_translation_key = f"{ENTITY_FAN_MODE}"
+        self._attr_translation_key = f"{TRANSLATION_KEY_FAN_MODE}"
         self._attr_icon = "mdi:fan"
         self._attr_options = self._fan_modes
 

--- a/custom_components/tuya_smart_ir_ac/translations/de-DE.json
+++ b/custom_components/tuya_smart_ir_ac/translations/de-DE.json
@@ -1,16 +1,13 @@
 {
   "entity": {
     "number": {
-      "temperature": {
-        "name": "Temperatur"
-      },
-      "temp_hvac_mode_auto": {
+      "hvac_mode_auto": {
         "name": "Automatisch"
       },
-      "temp_hvac_mode_cool": {
+      "hvac_mode_cool": {
         "name": "Kühlen"
       },
-      "temp_hvac_mode_heat": {
+      "hvac_mode_heat": {
         "name": "Heizen"
       }
     },
@@ -34,20 +31,11 @@
           "medium": "Mittel",
           "high": "Hoch"
         }
-      },
-      "fan_hvac_mode": {
-        "name": "Ventilatorgeschwindigkeit",
-        "state": {
-          "auto": "Automatisch",
-          "low": "Niedrig",
-          "medium": "Mittel",
-          "high": "Hoch"
-        }
       }
     }
   },
   "selector": {
-    "country": {
+    "countries": {
       "options": {
         "eu": "Europa",
         "us": "Amerika",
@@ -81,6 +69,15 @@
         "high": "Hoch"
       }
     },
+    "presets_modes": {
+      "options": {
+        "home": "Zuhause",
+        "sleep": "Schlafen",
+        "eco": "Eco",
+        "comfort": "Komfort",
+        "away": "Abwesend"
+      }
+    },
     "hvac_presets": {
       "options": {
         "fan_hvac_mode": "Standard-Ventilatorgeschwindigkeit",
@@ -96,21 +93,7 @@
         "temp_setpoint": "Temperatursteuerung"
       }
     },
-    "hvac_power_on": {
-      "options": {
-        "never": "Nie",
-        "always": "Immer",
-        "only_off": "Nur wenn ausgeschaltet (nicht empfohlen)"
-      }
-    },
-    "temp_power_on": {
-      "options": {
-        "never": "Nie",
-        "always": "Immer",
-        "only_off": "Nur wenn ausgeschaltet (nicht empfohlen)"
-      }
-    },
-    "fan_power_on": {
+    "power_on_modes": {
       "options": {
         "never": "Nie",
         "always": "Immer",
@@ -136,7 +119,8 @@
     "error": {
       "cannot_change_access_id": "Die Access ID kann für einen bestehenden Hub nicht geändert werden.",
       "cannot_connect_to_tuya": "Verbindung zu den Tuya-Servern fehlgeschlagen. Bitte überprüfen Sie Ihr Netzwerk.",
-      "invalid_auth": "Authentifizierung fehlgeschlagen: Ungültige Access ID oder Access Secret."
+      "invalid_auth": "Authentifizierung fehlgeschlagen: Ungültige Access ID oder Access Secret.",
+      "invalid_data_center": "Authentifizierung fehlgeschlagen: Ungültiges Rechenzentrum."
     }
   },
   "options": {
@@ -145,6 +129,7 @@
         "title": "Tuya Smart IR Konfiguration",
         "menu_options": {
           "device_management": "Geräteverwaltung",
+          "presets_management": "Global Presets Management",
           "hub_settings": "Hub-Einstellungen"
         }
       },
@@ -155,6 +140,24 @@
           "generic_management": "Verwaltung allgemeiner Geräte",
           "sensor_management": "Verwaltung von Temperatur-/Feuchtigkeitssensoren",
           "back_to_init": "⬅️ Zurück zum Hauptmenü"
+        }
+      },
+      "presets_management": {
+        "title": "Global Presets Management",
+        "description": "Select a preset and a mode to configure.",
+        "data": {
+          "preset": "Preset",
+          "hvac_mode": "Mode"
+        }
+      },
+      "preset_configure": {
+        "title": "Preset Configuration",
+        "description": "Configure temperature and fan mode for this preset.",
+        "data": {
+          "preset": "Selected Preset",
+          "hvac_mode": "Selected Mode",
+          "temp": "Target Temperature",
+          "fan": "Fan Speed"
         }
       },
       "climate_management": {
@@ -196,6 +199,7 @@
           "temp_step": "Temperaturschritt",
           "hvac_modes": "Unterstützte HVAC-Modi",
           "fan_modes": "Unterstützte Ventilatormodi",
+          "preset_modes": "Unterstützte Preset-Modi",
           "hvac_presets": "Automatische HVAC-Voreinstellungen",
           "optional_entities": "Optionale Entitäten"
         },
@@ -224,6 +228,7 @@
           "temp_step": "Temperaturschritt",
           "hvac_modes": "Unterstützte HVAC-Modi",
           "fan_modes": "Unterstützte Ventilatormodi",
+          "preset_modes": "Unterstützte Preset-Modi",
           "hvac_presets": "Automatische HVAC-Voreinstellungen",
           "optional_entities": "Optionale Entitäten"
         },
@@ -305,6 +310,7 @@
       "device_already_configured": "Dieses Gerät wurde bereits konfiguriert.",
       "device_already_configured_on_other_hub": "Dieses Gerät ist bereits auf einem anderen Hub konfiguriert.",
       "invalid_auth": "Authentifizierung fehlgeschlagen: Ungültige Access ID oder Access Secret.",
+      "invalid_data_center": "Authentifizierung fehlgeschlagen: Ungültiges Rechenzentrum.",
       "invalid_sensor_type": "Das ausgewählte Gerät ist kein gültiger Temperatur-/Feuchtigkeitssensor.",
       "tuya_api_error": "Tuya Cloud Fehler: {error_info}"
     },

--- a/custom_components/tuya_smart_ir_ac/translations/en.json
+++ b/custom_components/tuya_smart_ir_ac/translations/en.json
@@ -1,22 +1,19 @@
 {
   "entity": {
     "number": {
-      "temperature": {
-        "name": "Temperature"
-      },
-      "temp_hvac_mode_auto": {
+      "hvac_mode_auto": {
         "name": "Auto"
       },
-      "temp_hvac_mode_cool": {
+      "hvac_mode_cool": {
         "name": "Cool"
       },
-      "temp_hvac_mode_heat": {
+      "hvac_mode_heat": {
         "name": "Heat"
       }
     },
     "select": {
       "hvac_mode": {
-        "name": "HVAC mode",  
+        "name": "HVAC mode",
         "state": {
           "auto": "Auto",
           "cool": "Cool",
@@ -34,20 +31,11 @@
           "medium": "Medium",
           "high": "High"
         }
-      },
-      "fan_hvac_mode": {
-        "name": "Fan speed",
-        "state": {
-          "auto": "Auto",
-          "low": "Low",
-          "medium": "Medium",
-          "high": "High"
-        }
       }
     }
   },
   "selector": {
-    "country": {
+    "countries": {
       "options": {
         "eu": "Europe",
         "us": "America",
@@ -81,6 +69,15 @@
         "high": "High"
       }
     },
+    "presets_modes": {
+      "options": {
+        "home": "Home",
+        "sleep": "Sleep",
+        "eco": "Eco",
+        "comfort": "Comfort",
+        "away": "Away"
+      }
+    },
     "hvac_presets": {
       "options": {
         "fan_hvac_mode": "Default fan speed",
@@ -96,21 +93,7 @@
         "temp_setpoint": "Temperature control"
       }
     },
-    "hvac_power_on": {
-      "options": {
-        "never": "Never",
-        "always": "Always",
-        "only_off": "Only if turned off (not recommended)"
-      }
-    },
-    "temp_power_on": {
-      "options": {
-        "never": "Never",
-        "always": "Always",
-        "only_off": "Only if turned off (not recommended)"
-      }
-    },
-    "fan_power_on": {
+    "power_on_modes": {
       "options": {
         "never": "Never",
         "always": "Always",
@@ -136,7 +119,8 @@
     "error": {
       "cannot_change_access_id": "The Access ID cannot be modified for an existing hub.",
       "cannot_connect_to_tuya": "Failed to connect to Tuya servers. Please check your network.",
-      "invalid_auth": "Authentication failed: Invalid Access ID or Access Secret."
+      "invalid_auth": "Authentication failed: Invalid Access ID or Access Secret.",
+      "invalid_data_center": "Authentication failed: Invalid data center."
     }
   },
   "options": {
@@ -145,6 +129,7 @@
         "title": "Tuya Smart IR Configuration",
         "menu_options": {
           "device_management": "Device Management",
+          "presets_management": "Global Presets Management",
           "hub_settings": "Hub Settings"
         }
       },
@@ -155,6 +140,24 @@
           "generic_management": "Generic Devices Management",
           "sensor_management": "Temperature/Humidity Sensors Management",
           "back_to_init": "⬅️ Back to Main Menu"
+        }
+      },
+      "presets_management": {
+        "title": "Global Presets Management",
+        "description": "Select a preset and a mode to configure.",
+        "data": {
+          "preset": "Preset",
+          "hvac_mode": "Mode"
+        }
+      },
+      "preset_configure": {
+        "title": "Preset Configuration",
+        "description": "Configure temperature and fan mode for this preset.",
+        "data": {
+          "preset": "Selected Preset",
+          "hvac_mode": "Selected Mode",
+          "temp": "Target Temperature",
+          "fan": "Fan Speed"
         }
       },
       "climate_management": {
@@ -196,6 +199,7 @@
           "temp_step": "Step temperature",
           "hvac_modes": "Supported HVAC modes",
           "fan_modes": "Supported FAN modes",
+          "preset_modes": "Supported preset modes",
           "hvac_presets": "HVAC automatic presets",
           "optional_entities": "Optional entities"
         },
@@ -224,6 +228,7 @@
           "temp_step": "Step temperature",
           "hvac_modes": "Supported HVAC modes",
           "fan_modes": "Supported FAN modes",
+          "preset_modes": "Supported preset modes",
           "hvac_presets": "HVAC automatic presets",
           "optional_entities": "Optional entities"
         },
@@ -305,6 +310,7 @@
       "device_already_configured": "This device is already configured.",
       "device_already_configured_on_other_hub": "This device is already configured on other Hub.",
       "invalid_auth": "Authentication failed: Invalid Access ID or Access Secret.",
+      "invalid_data_center": "Authentication failed: Invalid data center.",
       "invalid_sensor_type": "The selected device is not a valid temperature/humidity sensor.",
       "tuya_api_error": "Tuya Cloud Error: {error_info}"
     },

--- a/custom_components/tuya_smart_ir_ac/translations/fr-FR.json
+++ b/custom_components/tuya_smart_ir_ac/translations/fr-FR.json
@@ -1,16 +1,13 @@
 {
   "entity": {
     "number": {
-      "temperature": {
-        "name": "Température"
-      },
-      "temp_hvac_mode_auto": {
+      "hvac_mode_auto": {
         "name": "Auto"
       },
-      "temp_hvac_mode_cool": {
+      "hvac_mode_cool": {
         "name": "Climatisation"
       },
-      "temp_hvac_mode_heat": {
+      "hvac_mode_heat": {
         "name": "Chauffage"
       }
     },
@@ -34,20 +31,11 @@
           "medium": "Moyenne",
           "high": "Haute"
         }
-      },
-      "fan_hvac_mode": {
-        "name": "Vitesse du ventilateur",
-        "state": {
-          "auto": "Auto",
-          "low": "Basse",
-          "medium": "Moyenne",
-          "high": "Haute"
-        }
       }
     }
   },
   "selector": {
-    "country": {
+    "countries": {
       "options": {
         "eu": "Europe",
         "us": "Amérique",
@@ -81,6 +69,15 @@
         "high": "Haute"
       }
     },
+    "presets_modes": {
+      "options": {
+        "home": "Domicile",
+        "sleep": "Sommeil",
+        "eco": "Éco",
+        "comfort": "Confort",
+        "away": "Absent"
+      }
+    },
     "hvac_presets": {
       "options": {
         "fan_hvac_mode": "Vitesse du ventilateur par défaut",
@@ -96,21 +93,7 @@
         "temp_setpoint": "Contrôle de la température"
       }
     },
-    "hvac_power_on": {
-      "options": {
-        "never": "Jamais",
-        "always": "Toujours",
-        "only_off": "Uniquement si éteint (non recommandé)"
-      }
-    },
-    "temp_power_on": {
-      "options": {
-        "never": "Jamais",
-        "always": "Toujours",
-        "only_off": "Uniquement si éteint (non recommandé)"
-      }
-    },
-    "fan_power_on": {
+    "power_on_modes": {
       "options": {
         "never": "Jamais",
         "always": "Toujours",
@@ -136,7 +119,8 @@
     "error": {
       "cannot_change_access_id": "L'Access ID ne peut pas être modifié pour un hub existant.",
       "cannot_connect_to_tuya": "Échec de la connexion aux serveurs Tuya. Veuillez vérifier votre réseau.",
-      "invalid_auth": "Échec de l'authentification : Access ID ou Access Secret incorrect."
+      "invalid_auth": "Échec de l'authentification : Access ID ou Access Secret incorrect.",
+      "invalid_data_center": "Échec de l'authentification : centre de données invalide."
     }
   },
   "options": {
@@ -145,6 +129,7 @@
         "title": "Configuration Tuya Smart IR",
         "menu_options": {
           "device_management": "Gestion des appareils",
+          "presets_management": "Global Presets Management",
           "hub_settings": "Paramètres du Hub"
         }
       },
@@ -155,6 +140,24 @@
           "generic_management": "Gestion des appareils génériques",
           "sensor_management": "Gestion des capteurs de température/humidité",
           "back_to_init": "⬅️ Retour au menu principal"
+        }
+      },
+      "presets_management": {
+        "title": "Global Presets Management",
+        "description": "Select a preset and a mode to configure.",
+        "data": {
+          "preset": "Preset",
+          "hvac_mode": "Mode"
+        }
+      },
+      "preset_configure": {
+        "title": "Preset Configuration",
+        "description": "Configure temperature and fan mode for this preset.",
+        "data": {
+          "preset": "Selected Preset",
+          "hvac_mode": "Selected Mode",
+          "temp": "Target Temperature",
+          "fan": "Fan Speed"
         }
       },
       "climate_management": {
@@ -196,6 +199,7 @@
           "temp_step": "Pas de température",
           "hvac_modes": "Modes HVAC pris en charge",
           "fan_modes": "Modes de ventilation pris en charge",
+          "preset_modes": "Modes prédéfinis pris en charge",
           "hvac_presets": "Préréglages automatiques HVAC",
           "optional_entities": "Entités optionnelles"
         },
@@ -224,6 +228,7 @@
           "temp_step": "Pas de température",
           "hvac_modes": "Modes HVAC pris en charge",
           "fan_modes": "Modes de ventilation pris en charge",
+          "preset_modes": "Modes prédéfinis pris en charge",
           "hvac_presets": "Préréglages automatiques HVAC",
           "optional_entities": "Entités optionnelles"
         },
@@ -305,6 +310,7 @@
       "device_already_configured": "Cet appareil a déjà été configuré.",
       "device_already_configured_on_other_hub": "Cet appareil est déjà configuré sur un autre Hub.",
       "invalid_auth": "Échec de l'authentification : Access ID ou Access Secret incorrect.",
+      "invalid_data_center": "Échec de l'authentification : centre de données invalide.",
       "invalid_sensor_type": "Le dispositif sélectionné n'est pas un capteur de température/humidité valide.",
       "tuya_api_error": "Erreur Cloud Tuya: {error_info}"
     },

--- a/custom_components/tuya_smart_ir_ac/translations/it.json
+++ b/custom_components/tuya_smart_ir_ac/translations/it.json
@@ -1,22 +1,19 @@
 {
   "entity": {
     "number": {
-      "temperature": {
-        "name": "Temperatura"
-      },
-      "temp_hvac_mode_auto": {
+      "hvac_mode_auto": {
         "name": "Auto"
       },
-      "temp_hvac_mode_cool": {
+      "hvac_mode_cool": {
         "name": "Freddo"
       },
-      "temp_hvac_mode_heat": {
+      "hvac_mode_heat": {
         "name": "Caldo"
       }
     },
     "select": {
       "hvac_mode": {
-        "name": "Modalità HVAC",  
+        "name": "Modalità HVAC",
         "state": {
           "auto": "Automatico",
           "cool": "Freddo",
@@ -34,20 +31,11 @@
           "medium": "Medio",
           "high": "Alto"
         }
-      },
-      "fan_hvac_mode": {
-        "name": "Velocità ventola",
-        "state": {
-          "auto": "Auto",
-          "low": "Basso",
-          "medium": "Medio",
-          "high": "Alto"
-        }
       }
     }
   },
   "selector": {
-    "country": {
+    "countries": {
       "options": {
         "eu": "Europa",
         "us": "America",
@@ -81,6 +69,15 @@
         "high": "Alto"
       }
     },
+    "presets_modes": {
+      "options": {
+        "home": "In casa",
+        "sleep": "Sonno",
+        "eco": "Eco",
+        "comfort": "Comfort",
+        "away": "Fuori casa"
+      }
+    },
     "hvac_presets": {
       "options": {
         "fan_hvac_mode": "Velocità ventola di default",
@@ -96,21 +93,7 @@
         "temp_setpoint": "Controllo temperatura"
       }
     },
-    "hvac_power_on": {
-      "options": {
-        "never": "Mai",
-        "always": "Sempre",
-        "only_off": "Solo se spento (non consigliato)"
-      }
-    },
-    "temp_power_on": {
-      "options": {
-        "never": "Mai",
-        "always": "Sempre",
-        "only_off": "Solo se spento (non consigliato)"
-      }
-    },
-    "fan_power_on": {
+    "power_on_modes": {
       "options": {
         "never": "Mai",
         "always": "Sempre",
@@ -136,7 +119,8 @@
     "error": {
       "cannot_change_access_id": "L'Access ID non può essere modificato per un hub esistente.",
       "cannot_connect_to_tuya": "Impossibile connettersi ai server Tuya. Verifica la rete.",
-      "invalid_auth": "Autenticazione fallita: Access ID o Access Secret errati."
+      "invalid_auth": "Autenticazione fallita: Access ID o Access Secret errati.",
+      "invalid_data_center": "Autenticazione fallita: Data center errato."
     }
   },
   "options": {
@@ -145,6 +129,7 @@
         "title": "Configurazione Tuya Smart IR",
         "menu_options": {
           "device_management": "Gestione Dispositivi",
+          "presets_management": "Gestione Preset Globali",
           "hub_settings": "Impostazioni Hub"
         }
       },
@@ -155,6 +140,24 @@
           "generic_management": "Gestione Dispositivi Generici",
           "sensor_management": "Gestione Sensori Temperatura/Umidità",
           "back_to_init": "⬅️ Torna al menu principale"
+        }
+      },
+      "presets_management": {
+        "title": "Gestione Preset Globali",
+        "description": "Seleziona un preset e una modalità da configurare.",
+        "data": {
+          "preset": "Preset",
+          "hvac_mode": "Modalità"
+        }
+      },
+      "preset_configure": {
+        "title": "Configurazione Preset",
+        "description": "Configura la temperatura e la ventilazione per questo preset.",
+        "data": {
+          "preset": "Preset Selezionato",
+          "hvac_mode": "Modalità Selezionata",
+          "temp": "Temperatura Target",
+          "fan": "Velocità Ventola"
         }
       },
       "climate_management": {
@@ -196,6 +199,7 @@
           "temp_step": "Temperatura step",
           "hvac_modes": "Modalità HVAC supportate",
           "fan_modes": "Modalità ventilazione supportate",
+          "preset_modes": "Modalità preset supportate",
           "hvac_presets": "Preset automatici HVAC",
           "optional_entities": "Entità opzionali"
         },
@@ -224,6 +228,7 @@
           "temp_step": "Temperatura step",
           "hvac_modes": "Modalità HVAC supportate",
           "fan_modes": "Modalità ventilazione supportate",
+          "preset_modes": "Modalità preset supportate",
           "hvac_presets": "Preset automatici HVAC",
           "optional_entities": "Entità opzionali"
         },
@@ -305,6 +310,7 @@
       "device_already_configured": "Questo dispositivo è già configurato.",
       "device_already_configured_on_other_hub": "Questo dispositivo è già configurato su un altro Hub.",
       "invalid_auth": "Autenticazione fallita: Access ID o Access Secret errati.",
+      "invalid_data_center": "Autenticazione fallita: Data center errato.",
       "invalid_sensor_type": "Il dispositivo selezionato non è un sensore di temperatura/umidità valido.",
       "tuya_api_error": "Errore Cloud Tuya: {error_info}"
     },

--- a/custom_components/tuya_smart_ir_ac/translations/nl-NL.json
+++ b/custom_components/tuya_smart_ir_ac/translations/nl-NL.json
@@ -1,16 +1,13 @@
 {
   "entity": {
     "number": {
-      "temperature": {
-        "name": "Temperatuur"
-      },
-      "temp_hvac_mode_auto": {
+      "hvac_mode_auto": {
         "name": "Automatisch"
       },
-      "temp_hvac_mode_cool": {
+      "hvac_mode_cool": {
         "name": "Koelen"
       },
-      "temp_hvac_mode_heat": {
+      "hvac_mode_heat": {
         "name": "Verwarmen"
       }
     },
@@ -34,20 +31,11 @@
           "medium": "Middel",
           "high": "Hoog"
         }
-      },
-      "fan_hvac_mode": {
-        "name": "Ventilatorsnelheid",
-        "state": {
-          "auto": "Automatisch",
-          "low": "Laag",
-          "medium": "Middel",
-          "high": "Hoog"
-        }
       }
     }
   },
   "selector": {
-    "country": {
+    "countries": {
       "options": {
         "eu": "Europa",
         "us": "Amerika",
@@ -81,6 +69,15 @@
         "high": "Hoog"
       }
     },
+    "presets_modes": {
+      "options": {
+        "home": "Thuis",
+        "sleep": "Slapen",
+        "eco": "Eco",
+        "comfort": "Comfort",
+        "away": "Afwezig"
+      }
+    },
     "hvac_presets": {
       "options": {
         "fan_hvac_mode": "Standaard ventilatorsnelheid",
@@ -96,21 +93,7 @@
         "temp_setpoint": "Temperatuurregeling"
       }
     },
-    "hvac_power_on": {
-      "options": {
-        "never": "Nooit",
-        "always": "Altijd",
-        "only_off": "Alleen indien uitgeschakeld (niet aanbevolen)"
-      }
-    },
-    "temp_power_on": {
-      "options": {
-        "never": "Nooit",
-        "always": "Altijd",
-        "only_off": "Alleen indien uitgeschakeld (niet aanbevolen)"
-      }
-    },
-    "fan_power_on": {
+    "power_on_modes": {
       "options": {
         "never": "Nooit",
         "always": "Altijd",
@@ -136,7 +119,8 @@
     "error": {
       "cannot_change_access_id": "De Access ID kan niet worden gewijzigd voor een bestaande hub.",
       "cannot_connect_to_tuya": "Verbinding met Tuya-servers mislukt. Controleer uw netwerk.",
-      "invalid_auth": "Verificatie mislukt: Ongeldige Access ID of Access Secret."
+      "invalid_auth": "Verificatie mislukt: Ongeldige Access ID of Access Secret.",
+      "invalid_data_center": "Verificatie mislukt: Ongeldige data-centrum."
     }
   },
   "options": {
@@ -145,6 +129,7 @@
         "title": "Tuya Smart IR Configuratie",
         "menu_options": {
           "device_management": "Apparaatbeheer",
+          "presets_management": "Global Presets Management",
           "hub_settings": "Hub-instellingen"
         }
       },
@@ -155,6 +140,24 @@
           "generic_management": "Generiek apparaatbeheer",
           "sensor_management": "Temperatuur-/vochtigheidssensoren beheer",
           "back_to_init": "⬅️ Terug naar hoofdmenu"
+        }
+      },
+      "presets_management": {
+        "title": "Global Presets Management",
+        "description": "Select a preset and a mode to configure.",
+        "data": {
+          "preset": "Preset",
+          "hvac_mode": "Mode"
+        }
+      },
+      "preset_configure": {
+        "title": "Preset Configuration",
+        "description": "Configure temperature and fan mode for this preset.",
+        "data": {
+          "preset": "Selected Preset",
+          "hvac_mode": "Selected Mode",
+          "temp": "Target Temperature",
+          "fan": "Fan Speed"
         }
       },
       "climate_management": {
@@ -196,6 +199,7 @@
           "temp_step": "Temperatuurstap",
           "hvac_modes": "Ondersteunde HVAC-modi",
           "fan_modes": "Ondersteunde ventilatormodi",
+          "preset_modes": "Ondersteunde voorinstellingen",
           "hvac_presets": "HVAC automatische voorinstellingen",
           "optional_entities": "Optionele entiteiten"
         },
@@ -224,6 +228,7 @@
           "temp_step": "Temperatuurstap",
           "hvac_modes": "Ondersteunde HVAC-modi",
           "fan_modes": "Ondersteunde ventilatormodi",
+          "preset_modes": "Ondersteunde voorinstellingen",
           "hvac_presets": "HVAC automatische voorinstellingen",
           "optional_entities": "Optionele entiteiten"
         },
@@ -305,6 +310,7 @@
       "device_already_configured": "Dit apparaat is al geconfigureerd.",
       "device_already_configured_on_other_hub": "Dit apparaat is al geconfigureerd op een andere Hub.",
       "invalid_auth": "Verificatie mislukt: Ongeldige Access ID of Access Secret.",
+      "invalid_data_center": "Verificatie mislukt: Ongeldige data-centrum.",
       "invalid_sensor_type": "Het geselecteerde apparaat is geen geldige temperatuur-/vochtigheidssensor.",
       "tuya_api_error": "Tuya Cloud Fout: {error_info}"
     },

--- a/custom_components/tuya_smart_ir_ac/translations/pt-BR.json
+++ b/custom_components/tuya_smart_ir_ac/translations/pt-BR.json
@@ -1,16 +1,13 @@
 {
   "entity": {
     "number": {
-      "temperature": {
-        "name": "Temperatura"
-      },
-      "temp_hvac_mode_auto": {
+      "hvac_mode_auto": {
         "name": "Automático"
       },
-      "temp_hvac_mode_cool": {
+      "hvac_mode_cool": {
         "name": "Resfriar"
       },
-      "temp_hvac_mode_heat": {
+      "hvac_mode_heat": {
         "name": "Aquecimento"
       }
     },
@@ -34,20 +31,11 @@
           "medium": "Média",
           "high": "Alta"
         }
-      },
-      "fan_hvac_mode": {
-        "name": "Velocidade do ventilador",
-        "state": {
-          "auto": "Automático",
-          "low": "Baixa",
-          "medium": "Média",
-          "high": "Alta"
-        }
       }
     }
   },
   "selector": {
-    "country": {
+    "countries": {
       "options": {
         "eu": "Europa",
         "us": "América",
@@ -81,6 +69,15 @@
         "high": "Alta"
       }
     },
+    "presets_modes": {
+      "options": {
+        "home": "Casa",
+        "sleep": "Dormir",
+        "eco": "Eco",
+        "comfort": "Conforto",
+        "away": "Ausente"
+      }
+    },
     "hvac_presets": {
       "options": {
         "fan_hvac_mode": "Velocidade padrão do ventilador",
@@ -96,21 +93,7 @@
         "temp_setpoint": "Controle de temperatura"
       }
     },
-    "hvac_power_on": {
-      "options": {
-        "never": "Nunca",
-        "always": "Sempre",
-        "only_off": "Somente se estiver desligado (não recomendado)"
-      }
-    },
-    "temp_power_on": {
-      "options": {
-        "never": "Nunca",
-        "always": "Sempre",
-        "only_off": "Somente se estiver desligado (não recomendado)"
-      }
-    },
-    "fan_power_on": {
+    "power_on_modes": {
       "options": {
         "never": "Nunca",
         "always": "Sempre",
@@ -136,7 +119,8 @@
     "error": {
       "cannot_change_access_id": "O Access ID não pode ser modificado para um hub existente.",
       "cannot_connect_to_tuya": "Falha ao conectar aos servidores da Tuya. Por favor, verifique sua rede.",
-      "invalid_auth": "Falha na autenticação: Access ID ou Access Secret inválidos."
+      "invalid_auth": "Falha na autenticação: Access ID ou Access Secret inválidos.",
+      "invalid_data_center": "Falha na autenticação: Centro de dados inválido."
     }
   },
   "options": {
@@ -145,6 +129,7 @@
         "title": "Configuração do Tuya Smart IR",
         "menu_options": {
           "device_management": "Gerenciamento de Dispositivos",
+          "presets_management": "Global Presets Management",
           "hub_settings": "Configurações do Hub"
         }
       },
@@ -155,6 +140,24 @@
           "generic_management": "Gerenciamento de Dispositivos Genéricos",
           "sensor_management": "Gerenciamento de Sensores de Temperatura/Umidade",
           "back_to_init": "⬅️ Voltar ao Menu Principal"
+        }
+      },
+      "presets_management": {
+        "title": "Global Presets Management",
+        "description": "Select a preset and a mode to configure.",
+        "data": {
+          "preset": "Preset",
+          "hvac_mode": "Mode"
+        }
+      },
+      "preset_configure": {
+        "title": "Preset Configuration",
+        "description": "Configure temperature and fan mode for this preset.",
+        "data": {
+          "preset": "Selected Preset",
+          "hvac_mode": "Selected Mode",
+          "temp": "Target Temperature",
+          "fan": "Fan Speed"
         }
       },
       "climate_management": {
@@ -196,6 +199,7 @@
           "temp_step": "Incremento de temperatura",
           "hvac_modes": "Modos de HVAC suportados",
           "fan_modes": "Modos de ventilador suportados",
+          "preset_modes": "Modos de preset suportados",
           "hvac_presets": "Predefinições automáticas de HVAC",
           "optional_entities": "Entidades opcionais"
         },
@@ -224,6 +228,7 @@
           "temp_step": "Incremento de temperatura",
           "hvac_modes": "Modos de HVAC suportados",
           "fan_modes": "Modos de ventilador suportados",
+          "preset_modes": "Modos de preset suportados",
           "hvac_presets": "Predefinições automáticas de HVAC",
           "optional_entities": "Entidades opcionais"
         },
@@ -305,6 +310,7 @@
       "device_already_configured": "Este dispositivo já foi configurado.",
       "device_already_configured_on_other_hub": "Este dispositivo já está configurado em outro Hub.",
       "invalid_auth": "Falha na autenticação: Access ID ou Access Secret inválidos.",
+      "invalid_data_center": "Falha na autenticação: Centro de dados inválido.",
       "invalid_sensor_type": "O dispositivo selecionado não é um sensor de temperatura/umidade válido.",
       "tuya_api_error": "Erro na Cloud Tuya: {error_info}"
     },

--- a/custom_components/tuya_smart_ir_ac/translations/pt-PT.json
+++ b/custom_components/tuya_smart_ir_ac/translations/pt-PT.json
@@ -1,16 +1,13 @@
 {
   "entity": {
     "number": {
-      "temperature": {
-        "name": "Temperatura"
-      },
-      "temp_hvac_mode_auto": {
+      "hvac_mode_auto": {
         "name": "Automático"
       },
-      "temp_hvac_mode_cool": {
+      "hvac_mode_cool": {
         "name": "Arrefecimento"
       },
-      "temp_hvac_mode_heat": {
+      "hvac_mode_heat": {
         "name": "Aquecimento"
       }
     },
@@ -34,20 +31,11 @@
           "medium": "Média",
           "high": "Alta"
         }
-      },
-      "fan_hvac_mode": {
-        "name": "Velocidade da ventoinha",
-        "state": {
-          "auto": "Automático",
-          "low": "Baixa",
-          "medium": "Média",
-          "high": "Alta"
-        }
       }
     }
   },
   "selector": {
-    "country": {
+    "countries": {
       "options": {
         "eu": "Europa",
         "us": "América",
@@ -81,6 +69,15 @@
         "high": "Alta"
       }
     },
+    "presets_modes": {
+      "options": {
+        "home": "Casa",
+        "sleep": "Repouso",
+        "eco": "Eco",
+        "comfort": "Conforto",
+        "away": "Ausente"
+      }
+    },
     "hvac_presets": {
       "options": {
         "fan_hvac_mode": "Velocidade padrão da ventoinha",
@@ -96,21 +93,7 @@
         "temp_setpoint": "Controlo de temperatura"
       }
     },
-    "hvac_power_on": {
-      "options": {
-        "never": "Nunca",
-        "always": "Sempre",
-        "only_off": "Apenas se estiver desligado (non recomendado)"
-      }
-    },
-    "temp_power_on": {
-      "options": {
-        "never": "Nunca",
-        "always": "Sempre",
-        "only_off": "Apenas se estiver desligado (non recomendado)"
-      }
-    },
-    "fan_power_on": {
+    "power_on_modes": {
       "options": {
         "never": "Nunca",
         "always": "Sempre",
@@ -127,6 +110,7 @@
           "access_id": "ID de acesso Tuya",
           "access_secret": "Chave secreta de acesso Tuya",
           "country": "API do país Tuya",
+          "enable_pulsar": "Ativar fluxo Tuya Pulsar",
           "climate_update_interval": "Intervalo de atualização do ar condicionado",
           "sensor_update_interval": "Intervalo de atualização do sensor de temperatura/humidade"
         }
@@ -135,7 +119,8 @@
     "error": {
       "cannot_change_access_id": "O Access ID não pode ser modificado para um hub existente.",
       "cannot_connect_to_tuya": "Falha ao ligar aos servidores da Tuya. Por favor, verifique a sua rede.",
-      "invalid_auth": "Falha na autenticação: Access ID ou Access Secret inválidos."
+      "invalid_auth": "Falha na autenticação: Access ID ou Access Secret inválidos.",
+      "invalid_data_center": "Falha na autenticação: Centro de dados inválido."
     }
   },
   "options": {
@@ -144,6 +129,7 @@
         "title": "Configuração do Tuya Smart IR",
         "menu_options": {
           "device_management": "Gestão de Dispositivos",
+          "presets_management": "Global Presets Management",
           "hub_settings": "Configurações do Hub"
         }
       },
@@ -154,6 +140,24 @@
           "generic_management": "Gestão de Dispositivos Genéricos",
           "sensor_management": "Gestão de Sensores de Temperatura/Humidade",
           "back_to_init": "⬅️ Voltar ao Menu Principal"
+        }
+      },
+      "presets_management": {
+        "title": "Global Presets Management",
+        "description": "Select a preset and a mode to configure.",
+        "data": {
+          "preset": "Preset",
+          "hvac_mode": "Mode"
+        }
+      },
+      "preset_configure": {
+        "title": "Preset Configuration",
+        "description": "Configure temperature and fan mode for this preset.",
+        "data": {
+          "preset": "Selected Preset",
+          "hvac_mode": "Selected Mode",
+          "temp": "Target Temperature",
+          "fan": "Fan Speed"
         }
       },
       "climate_management": {
@@ -195,6 +199,7 @@
           "temp_step": "Incremento de temperatura",
           "hvac_modes": "Modos de HVAC suportados",
           "fan_modes": "Modos de ventoinha suportados",
+          "preset_modes": "Modos de preset suportados",
           "hvac_presets": "Predefinições automáticas de HVAC",
           "optional_entities": "Entidades opcionais"
         },
@@ -223,6 +228,7 @@
           "temp_step": "Incremento da temperatura",
           "hvac_modes": "Modos de HVAC suportados",
           "fan_modes": "Modos de ventoinha suportados",
+          "preset_modes": "Modos de preset suportados",
           "hvac_presets": "Predefinições automáticas de HVAC",
           "optional_entities": "Entidades opcionais"
         },
@@ -271,6 +277,7 @@
           "access_id": "ID de acesso Tuya",
           "access_secret": "Chave secreta de acesso Tuya",
           "country": "API do país Tuya",
+          "enable_pulsar": "Ativar Tuya Pulsar Stream",
           "climate_update_interval": "Intervalo de atualização do ar condicionado",
           "sensor_update_interval": "Intervalo de atualização do sensor de temperatura/humidade"
         }
@@ -303,6 +310,7 @@
       "device_already_configured": "Este dispositivo já foi configurado.",
       "device_already_configured_on_other_hub": "Este dispositivo já está configurado noutro Hub.",
       "invalid_auth": "Falha na autenticação: Access ID ou Access Secret inválidos.",
+      "invalid_data_center":"Falha na autenticação: Centro de dados inválido.",
       "invalid_sensor_type": "O dispositivo selecionado não é um sensor de temperatura/umidade válido.",
       "tuya_api_error": "Erro na Cloud Tuya: {error_info}"
     },

--- a/custom_components/tuya_smart_ir_ac/translations/tr.json
+++ b/custom_components/tuya_smart_ir_ac/translations/tr.json
@@ -1,16 +1,13 @@
 {
   "entity": {
     "number": {
-      "temperature": {
-        "name": "Sıcaklık"
-      },
-      "temp_hvac_mode_auto": {
+      "hvac_mode_auto": {
         "name": "Otomatik"
       },
-      "temp_hvac_mode_cool": {
+      "hvac_mode_cool": {
         "name": "Soğutma"
       },
-      "temp_hvac_mode_heat": {
+      "hvac_mode_heat": {
         "name": "Isıtma"
       }
     },
@@ -34,20 +31,11 @@
           "medium": "Orta",
           "high": "Yüksek"
         }
-      },
-      "fan_hvac_mode": {
-        "name": "Fan hızı",
-        "state": {
-          "auto": "Otomatik",
-          "low": "Düşük",
-          "medium": "Orta",
-          "high": "Yüksek"
-        }
       }
     }
   },
   "selector": {
-    "country": {
+    "countries": {
       "options": {
         "eu": "Avrupa",
         "us": "Amerika",
@@ -81,6 +69,15 @@
         "high": "Yüksek"
       }
     },
+    "presets_modes": {
+      "options": {
+        "home": "Ev",
+        "sleep": "Uyku",
+        "eco": "Eko",
+        "comfort": "Konfor",
+        "away": "Dışarıda"
+      }
+    },
     "hvac_presets": {
       "options": {
         "fan_hvac_mode": "Varsayılan fan hızı",
@@ -96,21 +93,7 @@
         "temp_setpoint": "Sıcaklık kontrolü"
       }
     },
-    "hvac_power_on": {
-      "options": {
-        "never": "Asla",
-        "always": "Her zaman",
-        "only_off": "Yalnızca kapalıysa (önerilmez)"
-      }
-    },
-    "temp_power_on": {
-      "options": {
-        "never": "Asla",
-        "always": "Her zaman",
-        "only_off": "Yalnızca kapalıysa (önerilmez)"
-      }
-    },
-    "fan_power_on": {
+    "power_on_modes": {
       "options": {
         "never": "Asla",
         "always": "Her zaman",
@@ -127,6 +110,7 @@
           "access_id": "Tuya Access ID",
           "access_secret": "Tuya Access Secret",
           "country": "Tuya ülke API'si",
+          "enable_pulsar": "Tuya Pulsar Akışını Etkinleştir",
           "climate_update_interval": "Klima güncelleme aralığı",
           "sensor_update_interval": "Sıcaklık/nem güncelleme aralığı"
         }
@@ -135,7 +119,8 @@
     "error": {
       "cannot_change_access_id": "Mevcut bir hub için Access ID değiştirilemez.",
       "cannot_connect_to_tuya": "Tuya sunucularına bağlanılamadı. Lütfen ağınızı kontrol edin.",
-      "invalid_auth": "Kimlik doğrulama başarısız: Geçersiz Access ID veya Access Secret."
+      "invalid_auth": "Kimlik doğrulama başarısız: Geçersiz Access ID veya Access Secret.",
+      "invalid_data_center": "Kimlik doğrulama başarısız: Geçersiz veri merkez."
     }
   },
   "options": {
@@ -144,6 +129,7 @@
         "title": "Tuya Smart IR Yapılandırması",
         "menu_options": {
           "device_management": "Cihaz Yönetimi",
+          "presets_management": "Global Presets Management",
           "hub_settings": "Hub Ayarları"
         }
       },
@@ -154,6 +140,24 @@
           "generic_management": "Genel Cihaz Yönetimi",
           "sensor_management": "Sıcaklık/Nem Sensörleri Yönetimi",
           "back_to_init": "⬅️ Ana Menüye Geri Dön"
+        }
+      },
+      "presets_management": {
+        "title": "Global Presets Management",
+        "description": "Select a preset and a mode to configure.",
+        "data": {
+          "preset": "Preset",
+          "hvac_mode": "Mode"
+        }
+      },
+      "preset_configure": {
+        "title": "Preset Configuration",
+        "description": "Configure temperature and fan mode for this preset.",
+        "data": {
+          "preset": "Selected Preset",
+          "hvac_mode": "Selected Mode",
+          "temp": "Target Temperature",
+          "fan": "Fan Speed"
         }
       },
       "climate_management": {
@@ -195,6 +199,7 @@
           "temp_step": "Sıcaklık adımı",
           "hvac_modes": "Desteklenen HVAC modları",
           "fan_modes": "Desteklenen FAN modları",
+          "preset_modes": "Desteklenen ön ayar modları",
           "hvac_presets": "HVAC otomatik ön ayarları",
           "optional_entities": "İsteğe bağlı varlıklar"
         },
@@ -223,6 +228,7 @@
           "temp_step": "Sıcaklık adımı",
           "hvac_modes": "Desteklenen HVAC modları",
           "fan_modes": "Desteklenen FAN modları",
+          "preset_modes": "Desteklenen ön ayar modları",
           "hvac_presets": "HVAC otomatik ön ayarları",
           "optional_entities": "İsteğe bağlı varlıklar"
         },
@@ -271,6 +277,7 @@
           "access_id": "Tuya Access ID",
           "access_secret": "Tuya Access Secret",
           "country": "Tuya ülke API'si",
+          "enable_pulsar": "Tuya Pulsar Akışını Etkinleştir",
           "climate_update_interval": "Klima güncelleme aralığı",
           "sensor_update_interval": "Sıcaklık/nem güncelleme aralığı"
         }
@@ -303,6 +310,7 @@
       "device_already_configured": "Bu cihaz zaten yapılandırılmış.",
       "device_already_configured_on_other_hub": "Bu cihaz zaten başka bir Hub üzerinde yapılandırılmış.",
       "invalid_auth": "Kimlik doğrulama başarısız: Geçersiz Access ID veya Access Secret.",
+      "invalid_data_center": "Kimlik doğrulama başarısız: Geçersiz veri merkez.",
       "invalid_sensor_type": "Seçilen cihaz geçerli bir sıcaklık/nem sensörü değildir.",
       "tuya_api_error": "Tuya Cloud Hatası: {error_info}"
     },


### PR DESCRIPTION
# Changelog 2026.6.4

We have overhauled the climate control system by introducing **Climate Presets**. You can now manage your home climate with a single click across all your devices.

### 🌟 New Feature: Climate Presets
You can enable or disable pre-defined climate profiles for each air conditioner. **All temperature and fan parameters are configured globally** via the Hub settings to ensure consistent performance.

* **Centralized Config:** Define settings once in the Hub.
* **Granular Control:** Choose which specific presets to enable for each individual unit.
* **Off-State Smart Memory:** You can now select and activate presets even when the A/C unit is turned off. The system intelligently remembers the last valid operational mode (COOL or HEAT) to apply the correct preset configuration immediately upon wake-up.

---

## 🛠️ System Optimizations

* **Intelligent Reload:** The Hub now updates settings without unnecessarily dropping Tuya connections. A full reload is only triggered when strictly required.
* **UI State Fixes:** Resolved an issue where the last active preset remained visually stuck on the Home Assistant dashboard after turning the climate device off. The preset state now correctly clears to `None` when the unit is powered down.
* **Stability & Code Robustness:** Refactored internal state tracking using inclusive whitelisting for HVAC modes, ensuring a smoother, safer, and more reliable experience.