### PR TITLE
Enhance custom power-on configuration with scene support and fixes & zh-Hant translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Tuya Smart IR AC Integration for Home Assistant
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
+[![Stable](https://img.shields.io/github/v/release/EnzoD86/tuya-smart-ir-ac)](https://github.com/EnzoD86/tuya-smart-ir-ac/releases/latest)
+[![Donate](https://img.shields.io/badge/donate-BuyMeCoffee-yellow.svg)](https://www.buymeacoffee.com/enzod86)
 
 This integration allows you to control Air Conditioners and generic infrared devices managed via a Tuya Smart IR Hub using the Tuya IoT Cloud Platform. It provides real-time status updates and local-like responsiveness via the Tuya Pulsar messaging service.
 
@@ -25,7 +27,7 @@ The easiest way to install this integration and receive automatic updates is thr
 4. Search for `Tuya Smart IR AC` and click **Download**.
 5. **Restart** Home Assistant to apply the changes.
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=cornguo&repository=tuya-smart-ir-ac&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=EnzoD86&repository=tuya-smart-ir-ac&category=integration)
 
 ### Method 2: Manual Installation
 1. Download the latest release from the GitHub repository.
@@ -155,3 +157,8 @@ Home Assistant needs to be restarted after this change.
 
 ## Contributions are welcome!
 If you have ideas to contribute to the project, open a pull request and we will evaluate together how to implement the improvement. Thanks!
+
+## Support me
+I dedicate my free time to the development and support for this integration, if you appreciate my work and want to support me, you can buy me a coffee. Thanks!
+
+<a href="https://www.buymeacoffee.com/enzod86" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>

--- a/README.md
+++ b/README.md
@@ -130,9 +130,6 @@ If you ever need to adjust names, IDs, or settings, simply re-run the configurat
 
 To accommodate different types of Air Conditioners and smart home setups, the integration provides advanced compatibility options in the climate configuration step:
 
-### Send Power-Off Before Power-On
-Some AC units require a clean reset sequence to wake up correctly, or their discrete IR codes behave inconsistently. Enabling this option forces the integration to send a standard `power-off` command immediately before transmitting a `power-on` command.
-
 ### Custom Power-On Button or Scene
 If your AC does not respond to standard Tuya IR power commands, or if you want to perform a custom action when turning the AC on, you can configure a custom entity:
 * **Custom Button**: Select a `button` entity. When a power-on is required, the integration will trigger the custom button press followed by the standard IR commands.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Tuya Smart IR AC Integration for Home Assistant
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
-[![Stable](https://img.shields.io/github/v/release/EnzoD86/tuya-smart-ir-ac)](https://github.com/EnzoD86/tuya-smart-ir-ac/releases/latest)
-[![Donate](https://img.shields.io/badge/donate-BuyMeCoffee-yellow.svg)](https://www.buymeacoffee.com/enzod86)
 
 This integration allows you to control Air Conditioners and generic infrared devices managed via a Tuya Smart IR Hub using the Tuya IoT Cloud Platform. It provides real-time status updates and local-like responsiveness via the Tuya Pulsar messaging service.
 
@@ -27,7 +25,7 @@ The easiest way to install this integration and receive automatic updates is thr
 4. Search for `Tuya Smart IR AC` and click **Download**.
 5. **Restart** Home Assistant to apply the changes.
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=EnzoD86&repository=tuya-smart-ir-ac&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=cornguo&repository=tuya-smart-ir-ac&category=integration)
 
 ### Method 2: Manual Installation
 1. Download the latest release from the GitHub repository.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ If you ever need to adjust names, IDs, or settings, simply re-run the configurat
 
 ---
 
+## Compatibility & Custom Power-On Options
+
+To accommodate different types of Air Conditioners and smart home setups, the integration provides advanced compatibility options in the climate configuration step:
+
+### Send Power-Off Before Power-On
+Some AC units require a clean reset sequence to wake up correctly, or their discrete IR codes behave inconsistently. Enabling this option forces the integration to send a standard `power-off` command immediately before transmitting a `power-on` command.
+
+### Custom Power-On Button or Scene
+If your AC does not respond to standard Tuya IR power commands, or if you want to perform a custom action when turning the AC on, you can configure a custom entity:
+* **Custom Button**: Select a `button` entity. When a power-on is required, the integration will trigger the custom button press followed by the standard IR commands.
+* **Custom Scene**: Select a Home Assistant `scene`. When configured as a scene:
+  * The selected scene will trigger instead of the standard IR power-on commands.
+  * Standard power-on commands are completely skipped.
+  * The integration directly sends the mode/temperature/fan IR commands (or updates the UI state to ON) once the scene triggers, preventing any duplicate commands or conflicts.
+
+---
+
 ## Debugging
 
 If you encounter issues or want to inspect the real-time WebSocket connection traffic, you can enable detailed debug logging by adding the following block to your `configuration.yaml`:

--- a/README.md
+++ b/README.md
@@ -138,8 +138,3 @@ Home Assistant needs to be restarted after this change.
 
 ## Contributions are welcome!
 If you have ideas to contribute to the project, open a pull request and we will evaluate together how to implement the improvement. Thanks!
-
-## Support me
-I dedicate my free time to the development and support for this integration, if you appreciate my work and want to support me, you can buy me a coffee. Thanks!
-
-<a href="https://www.buymeacoffee.com/enzod86" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>

--- a/custom_components/tuya_smart_ir_ac/config_flow.py
+++ b/custom_components/tuya_smart_ir_ac/config_flow.py
@@ -935,7 +935,7 @@ def climate_data() -> dict[vol.Marker, Any]:
                     ): BooleanSelector(),
                     vol.Optional(CONF_CUSTOM_POWER_ON): EntitySelector(
                         EntitySelectorConfig(
-                            domain=Platform.BUTTON,
+                            domain=[Platform.BUTTON, Platform.SCENE],
                             multiple=False,
                         )
                     )

--- a/custom_components/tuya_smart_ir_ac/config_flow.py
+++ b/custom_components/tuya_smart_ir_ac/config_flow.py
@@ -940,7 +940,7 @@ def climate_data() -> dict[vol.Marker, Any]:
                     ): BooleanSelector(),
                     vol.Optional(CONF_CUSTOM_POWER_ON): EntitySelector(
                         EntitySelectorConfig(
-                            domain=["button", "scene"],
+                            domain=[Platform.BUTTON, Platform.SCENE],
                             multiple=False,
                         )
                     )

--- a/custom_components/tuya_smart_ir_ac/config_flow.py
+++ b/custom_components/tuya_smart_ir_ac/config_flow.py
@@ -40,6 +40,7 @@ from .const import (
     CONF_CLIMATE_UPDATE_INTERVAL,
     CONF_COMPATIBILITY_OPTIONS,
     CONF_CUSTOM_POWER_ON,
+    CONF_SEND_OFF_BEFORE_ON,
     CONF_DEVICE_ID,
     CONF_DRY_MIN_FAN,
     CONF_DRY_MIN_TEMP,
@@ -66,6 +67,7 @@ from .const import (
     DEFAULT_FAN_MODE,
     DEFAULT_DRY_MIN_FAN,
     DEFAULT_DRY_MIN_TEMP,
+    DEFAULT_SEND_OFF_BEFORE_ON,
     DEFAULT_ENABLE_PULSAR,
     DEFAULT_FAN_POWER_ON,
     DEFAULT_GLOBAL_PRESETS,
@@ -932,6 +934,9 @@ def climate_data() -> dict[vol.Marker, Any]:
                     ): BooleanSelector(),
                     vol.Optional(
                         CONF_DRY_MIN_FAN, default=DEFAULT_DRY_MIN_FAN
+                    ): BooleanSelector(),
+                    vol.Optional(
+                        CONF_SEND_OFF_BEFORE_ON, default=DEFAULT_SEND_OFF_BEFORE_ON
                     ): BooleanSelector(),
                     vol.Optional(CONF_CUSTOM_POWER_ON): EntitySelector(
                         EntitySelectorConfig(

--- a/custom_components/tuya_smart_ir_ac/config_flow.py
+++ b/custom_components/tuya_smart_ir_ac/config_flow.py
@@ -40,7 +40,6 @@ from .const import (
     CONF_CLIMATE_UPDATE_INTERVAL,
     CONF_COMPATIBILITY_OPTIONS,
     CONF_CUSTOM_POWER_ON,
-    CONF_SEND_OFF_BEFORE_ON,
     CONF_DEVICE_ID,
     CONF_DRY_MIN_FAN,
     CONF_DRY_MIN_TEMP,
@@ -67,7 +66,6 @@ from .const import (
     DEFAULT_FAN_MODE,
     DEFAULT_DRY_MIN_FAN,
     DEFAULT_DRY_MIN_TEMP,
-    DEFAULT_SEND_OFF_BEFORE_ON,
     DEFAULT_ENABLE_PULSAR,
     DEFAULT_FAN_POWER_ON,
     DEFAULT_GLOBAL_PRESETS,
@@ -934,9 +932,6 @@ def climate_data() -> dict[vol.Marker, Any]:
                     ): BooleanSelector(),
                     vol.Optional(
                         CONF_DRY_MIN_FAN, default=DEFAULT_DRY_MIN_FAN
-                    ): BooleanSelector(),
-                    vol.Optional(
-                        CONF_SEND_OFF_BEFORE_ON, default=DEFAULT_SEND_OFF_BEFORE_ON
                     ): BooleanSelector(),
                     vol.Optional(CONF_CUSTOM_POWER_ON): EntitySelector(
                         EntitySelectorConfig(

--- a/custom_components/tuya_smart_ir_ac/config_flow.py
+++ b/custom_components/tuya_smart_ir_ac/config_flow.py
@@ -940,7 +940,7 @@ def climate_data() -> dict[vol.Marker, Any]:
                     ): BooleanSelector(),
                     vol.Optional(CONF_CUSTOM_POWER_ON): EntitySelector(
                         EntitySelectorConfig(
-                            domain=[Platform.BUTTON, Platform.SCENE],
+                            domain=["button", "scene"],
                             multiple=False,
                         )
                     )

--- a/custom_components/tuya_smart_ir_ac/const.py
+++ b/custom_components/tuya_smart_ir_ac/const.py
@@ -78,6 +78,7 @@ CONF_FAN_POWER_ON = "fan_power_on"
 CONF_DRY_MIN_TEMP = "dry_min_temp"
 CONF_DRY_MIN_FAN = "dry_min_fan"
 CONF_CUSTOM_POWER_ON = "custom_power_on"
+CONF_SEND_OFF_BEFORE_ON = "send_off_before_on"
 CONF_SENSOR_TYPES = "sensor_types"
 CONF_TEMP_UNIT = "temp_unit"
 
@@ -99,6 +100,7 @@ DEFAULT_TEMP_POWER_ON = POWER_ON_NEVER
 DEFAULT_FAN_POWER_ON = POWER_ON_NEVER
 DEFAULT_DRY_MIN_TEMP = False
 DEFAULT_DRY_MIN_FAN = False
+DEFAULT_SEND_OFF_BEFORE_ON = False
 DEFAULT_ENABLE_PULSAR = False
 
 # Climate default fallbacks

--- a/custom_components/tuya_smart_ir_ac/const.py
+++ b/custom_components/tuya_smart_ir_ac/const.py
@@ -78,7 +78,6 @@ CONF_FAN_POWER_ON = "fan_power_on"
 CONF_DRY_MIN_TEMP = "dry_min_temp"
 CONF_DRY_MIN_FAN = "dry_min_fan"
 CONF_CUSTOM_POWER_ON = "custom_power_on"
-CONF_SEND_OFF_BEFORE_ON = "send_off_before_on"
 CONF_SENSOR_TYPES = "sensor_types"
 CONF_TEMP_UNIT = "temp_unit"
 
@@ -100,7 +99,6 @@ DEFAULT_TEMP_POWER_ON = POWER_ON_NEVER
 DEFAULT_FAN_POWER_ON = POWER_ON_NEVER
 DEFAULT_DRY_MIN_TEMP = False
 DEFAULT_DRY_MIN_FAN = False
-DEFAULT_SEND_OFF_BEFORE_ON = False
 DEFAULT_ENABLE_PULSAR = False
 
 # Climate default fallbacks

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -56,7 +56,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         """Check if the climate device is available in the fetched data."""
         return self.data and self.data.get(climate_id) is not None
 
-    async def _async_ensure_off_before_on(self, infrared_id: str, climate_id: str) -> None:
+    async def _async_power_on_twice(self, infrared_id: str, climate_id: str) -> None:
         """Ensure a power-off command is sent before any command that turns the device on."""
         climates = self.entry.options.get(DEVICE_TYPE_CLIMATES, [])
         send_off_before_on = DEFAULT_SEND_OFF_BEFORE_ON
@@ -76,7 +76,6 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
             return
 
         _LOGGER.debug("[%s] Sending power-off command before power-on", climate_id)
-        await self._api.async_send_command(infrared_id, climate_id, "power", "0")
         await self._api.async_send_command(infrared_id, climate_id, "power", "1")
     
     # =========================================================================
@@ -147,7 +146,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
     async def _send_power_command(self, infrared_id: str, climate_id: str, state: str) -> None:
         """Send raw power command and handle validation errors."""
         if state == "1":
-            await self._async_ensure_off_before_on(infrared_id, climate_id)
+            await self._async_power_on_twice(infrared_id, climate_id)
 
         _LOGGER.debug("[%s] Sending IR command to turn %s climate", climate_id, "ON" if state == "1" else "OFF")
         result = await self._api.async_send_command(infrared_id, climate_id, "power", state)
@@ -174,7 +173,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 
     async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str) -> None:
         """Send multi-command IR packet and handle validation errors."""
-        await self._async_ensure_off_before_on(infrared_id, climate_id)
+        await self._async_power_on_twice(infrared_id, climate_id)
 
         _LOGGER.debug("[%s] Sending combined IR packet -> Mode: %s, Temp: %s, Fan: %s", climate_id, hvac_mode, temperature, fan_mode)
         result = await self._api.async_send_multiple_command(

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -75,8 +75,9 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         if current_state and current_state.power == True:
             return
 
-        _LOGGER.debug("[%s] Sending power-off command before power-on", climate_id)
+        _LOGGER.debug("[%s] Sending additional power-on command with short sleep", climate_id)
         await self._api.async_send_command(infrared_id, climate_id, "power", "1")
+        await asyncio.sleep(0.5)
     
     # =========================================================================
     # PUBLIC ATOMIC COORDINATOR ACTIONS

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -56,7 +56,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         """Check if the climate device is available in the fetched data."""
         return self.data and self.data.get(climate_id) is not None
 
-    async def _async_power_on_twice(self, infrared_id: str, climate_id: str) -> None:
+    async def _async_ensure_off_before_on(self, infrared_id: str, climate_id: str) -> None:
         """Ensure a power-off command is sent before any command that turns the device on."""
         climates = self.entry.options.get(DEVICE_TYPE_CLIMATES, [])
         send_off_before_on = DEFAULT_SEND_OFF_BEFORE_ON
@@ -75,8 +75,8 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         if current_state and current_state.power == True:
             return
 
-        _LOGGER.debug("[%s] Sending additional power-on command with short sleep", climate_id)
-        await self._api.async_send_command(infrared_id, climate_id, "power", "1")
+        _LOGGER.debug("[%s] Sending power-off command before power-on", climate_id)
+        await self._api.async_send_command(infrared_id, climate_id, "power", "0")
         await asyncio.sleep(0.5)
     
     # =========================================================================
@@ -147,7 +147,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
     async def _send_power_command(self, infrared_id: str, climate_id: str, state: str) -> None:
         """Send raw power command and handle validation errors."""
         if state == "1":
-            await self._async_power_on_twice(infrared_id, climate_id)
+            await self._async_ensure_off_before_on(infrared_id, climate_id)
 
         _LOGGER.debug("[%s] Sending IR command to turn %s climate", climate_id, "ON" if state == "1" else "OFF")
         result = await self._api.async_send_command(infrared_id, climate_id, "power", state)
@@ -174,7 +174,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 
     async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str) -> None:
         """Send multi-command IR packet and handle validation errors."""
-        await self._async_power_on_twice(infrared_id, climate_id)
+        await self._async_ensure_off_before_on(infrared_id, climate_id)
 
         _LOGGER.debug("[%s] Sending combined IR packet -> Mode: %s, Temp: %s, Fan: %s", climate_id, hvac_mode, temperature, fan_mode)
         result = await self._api.async_send_multiple_command(

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -90,19 +90,19 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         await self._send_power_command(infrared_id, climate_id, "0")
         await self._async_force_update_data(climate_id, power=False)
 
-    async def async_set_temperature(self, infrared_id: str, climate_id: str, temperature: float, skip_ensure_off: bool = False):
+    async def async_set_temperature(self, infrared_id: str, climate_id: str, temperature: float):
         """Send IR command to set target temperature and update local cache."""
-        await self._send_temperature_command(infrared_id, climate_id, temperature, skip_ensure_off=skip_ensure_off)
+        await self._send_temperature_command(infrared_id, climate_id, temperature)
         await self._async_force_update_data(climate_id, power=True, temperature=temperature)
 
-    async def async_set_fan_mode(self, infrared_id: str, climate_id: str, fan_mode: str, skip_ensure_off: bool = False):
+    async def async_set_fan_mode(self, infrared_id: str, climate_id: str, fan_mode: str):
         """Send IR command to set fan mode and update local cache."""
-        await self._send_fan_mode_command(infrared_id, climate_id, fan_mode, skip_ensure_off=skip_ensure_off)
+        await self._send_fan_mode_command(infrared_id, climate_id, fan_mode)
         await self._async_force_update_data(climate_id, power=True, fan_mode=fan_mode)
 
-    async def async_set_hvac_mode(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str, skip_ensure_off: bool = False):
+    async def async_set_hvac_mode(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str):
         """Send a combined multi-command IR packet (Mode, Temp, Fan) and update local cache."""
-        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode, skip_ensure_off=skip_ensure_off)
+        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode)
         await self._async_force_update_data(climate_id, power=True, hvac_mode=hvac_mode, temperature=temperature, fan_mode=fan_mode)
 
     # =========================================================================
@@ -114,7 +114,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         _LOGGER.debug("[%s] Executing combined power-on and hvac mode configuration flow (%s)", climate_id, hvac_mode)
         
         await self._send_power_command(infrared_id, climate_id, "1")
-        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode, skip_ensure_off=True)
+        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode)
         
         await self._async_force_update_data(climate_id, power=True, hvac_mode=hvac_mode, temperature=temperature, fan_mode=fan_mode)
 
@@ -123,7 +123,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         _LOGGER.debug("[%s] Executing combined power-on and temperature configuration flow (%s)", climate_id, temperature)
 
         await self._send_power_command(infrared_id, climate_id, "1")
-        await self._send_temperature_command(infrared_id, climate_id, temperature, skip_ensure_off=True)
+        await self._send_temperature_command(infrared_id, climate_id, temperature)
 
         await self._async_force_update_data(climate_id, power=True, temperature=temperature)
 
@@ -132,7 +132,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         _LOGGER.debug("[%s] Executing combined power-on and fan mode configuration flow (%s)", climate_id, fan_mode)
 
         await self._send_power_command(infrared_id, climate_id, "1")
-        await self._send_fan_mode_command(infrared_id, climate_id, fan_mode, skip_ensure_off=True)
+        await self._send_fan_mode_command(infrared_id, climate_id, fan_mode)
 
         await self._async_force_update_data(climate_id, power=True, fan_mode=fan_mode)
 
@@ -152,30 +152,24 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
             translation_key = "climate_error_turn_on" if state == "1" else "climate_error_turn_off"
             raise ServiceValidationError(translation_domain=DOMAIN, translation_key=translation_key)
 
-    async def _send_temperature_command(self, infrared_id: str, climate_id: str, temperature: float, skip_ensure_off: bool = False) -> None:
+    async def _send_temperature_command(self, infrared_id: str, climate_id: str, temperature: float) -> None:
         """Send raw temperature command and handle validation errors."""
-        if not skip_ensure_off:
-            await self._async_ensure_off_before_on(infrared_id, climate_id)
         _LOGGER.debug("[%s] Sending IR command to set temperature to %s°C", climate_id, temperature)
         result = await self._api.async_send_command(infrared_id, climate_id, "temp", tuya_temp(temperature))
         if not result.success:
             _LOGGER.error("Failed to set temperature for climate %s: %s", climate_id, result.error_info)
             raise ServiceValidationError(translation_domain=DOMAIN, translation_key="climate_error_temperature")
 
-    async def _send_fan_mode_command(self, infrared_id: str, climate_id: str, fan_mode: str, skip_ensure_off: bool = False) -> None:
+    async def _send_fan_mode_command(self, infrared_id: str, climate_id: str, fan_mode: str) -> None:
         """Send raw fan mode command and handle validation errors."""
-        if not skip_ensure_off:
-            await self._async_ensure_off_before_on(infrared_id, climate_id)
         _LOGGER.debug("[%s] Sending IR command to set fan mode to %s", climate_id, fan_mode)
         result = await self._api.async_send_command(infrared_id, climate_id, "wind", tuya_wind(fan_mode))
         if not result.success:
             _LOGGER.error("Failed to set fan mode for climate %s: %s", climate_id, result.error_info)
             raise ServiceValidationError(translation_domain=DOMAIN, translation_key="climate_error_fan_mode")
 
-    async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str, skip_ensure_off: bool = False) -> None:
+    async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str) -> None:
         """Send multi-command IR packet and handle validation errors."""
-        if not skip_ensure_off:
-            await self._async_ensure_off_before_on(infrared_id, climate_id)
         _LOGGER.debug("[%s] Sending combined IR packet -> Mode: %s, Temp: %s, Fan: %s", climate_id, hvac_mode, temperature, fan_mode)
         result = await self._api.async_send_multiple_command(
             infrared_id, climate_id, "1", tuya_mode(hvac_mode), tuya_temp(temperature), tuya_wind(fan_mode)

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -73,11 +73,8 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         if not send_off_before_on:
             return
 
-        current_data = self.data.get(climate_id)
-        if current_data is None or not current_data.power:
-            _LOGGER.debug("[%s] Device is off, sending power-off command before power-on", climate_id)
-            await self._api.async_send_command(infrared_id, climate_id, "power", "0")
-            await self._async_force_update_data(climate_id, power=True)
+        _LOGGER.debug("[%s] Sending power-off command before power-on", climate_id)
+        await self._api.async_send_command(infrared_id, climate_id, "power", "0")
     
     # =========================================================================
     # PUBLIC ATOMIC COORDINATOR ACTIONS
@@ -117,7 +114,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         _LOGGER.debug("[%s] Executing combined power-on and hvac mode configuration flow (%s)", climate_id, hvac_mode)
         
         await self._send_power_command(infrared_id, climate_id, "1")
-        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode)
+        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode, skip_ensure_off=True)
         
         await self._async_force_update_data(climate_id, power=True, hvac_mode=hvac_mode, temperature=temperature, fan_mode=fan_mode)
 
@@ -126,7 +123,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         _LOGGER.debug("[%s] Executing combined power-on and temperature configuration flow (%s)", climate_id, temperature)
 
         await self._send_power_command(infrared_id, climate_id, "1")
-        await self._send_temperature_command(infrared_id, climate_id, temperature)
+        await self._send_temperature_command(infrared_id, climate_id, temperature, skip_ensure_off=True)
 
         await self._async_force_update_data(climate_id, power=True, temperature=temperature)
 
@@ -135,7 +132,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         _LOGGER.debug("[%s] Executing combined power-on and fan mode configuration flow (%s)", climate_id, fan_mode)
 
         await self._send_power_command(infrared_id, climate_id, "1")
-        await self._send_fan_mode_command(infrared_id, climate_id, fan_mode)
+        await self._send_fan_mode_command(infrared_id, climate_id, fan_mode, skip_ensure_off=True)
 
         await self._async_force_update_data(climate_id, power=True, fan_mode=fan_mode)
 
@@ -143,9 +140,9 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
     # PRIVATE LOW-LEVEL COMMAND HELPERS
     # =========================================================================
 
-    async def _send_power_command(self, infrared_id: str, climate_id: str, state: str) -> None:
+    async def _send_power_command(self, infrared_id: str, climate_id: str, state: str, skip_ensure_off: bool = False) -> None:
         """Send raw power command and handle validation errors."""
-        if state == "1":
+        if state == "1" and not skip_ensure_off:
             await self._async_ensure_off_before_on(infrared_id, climate_id)
 
         _LOGGER.debug("[%s] Sending IR command to turn %s climate", climate_id, "ON" if state == "1" else "OFF")
@@ -155,27 +152,30 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
             translation_key = "climate_error_turn_on" if state == "1" else "climate_error_turn_off"
             raise ServiceValidationError(translation_domain=DOMAIN, translation_key=translation_key)
 
-    async def _send_temperature_command(self, infrared_id: str, climate_id: str, temperature: float) -> None:
+    async def _send_temperature_command(self, infrared_id: str, climate_id: str, temperature: float, skip_ensure_off: bool = False) -> None:
         """Send raw temperature command and handle validation errors."""
-        await self._async_ensure_off_before_on(infrared_id, climate_id)
+        if not skip_ensure_off:
+            await self._async_ensure_off_before_on(infrared_id, climate_id)
         _LOGGER.debug("[%s] Sending IR command to set temperature to %s°C", climate_id, temperature)
         result = await self._api.async_send_command(infrared_id, climate_id, "temp", tuya_temp(temperature))
         if not result.success:
             _LOGGER.error("Failed to set temperature for climate %s: %s", climate_id, result.error_info)
             raise ServiceValidationError(translation_domain=DOMAIN, translation_key="climate_error_temperature")
 
-    async def _send_fan_mode_command(self, infrared_id: str, climate_id: str, fan_mode: str) -> None:
+    async def _send_fan_mode_command(self, infrared_id: str, climate_id: str, fan_mode: str, skip_ensure_off: bool = False) -> None:
         """Send raw fan mode command and handle validation errors."""
-        await self._async_ensure_off_before_on(infrared_id, climate_id)
+        if not skip_ensure_off:
+            await self._async_ensure_off_before_on(infrared_id, climate_id)
         _LOGGER.debug("[%s] Sending IR command to set fan mode to %s", climate_id, fan_mode)
         result = await self._api.async_send_command(infrared_id, climate_id, "wind", tuya_wind(fan_mode))
         if not result.success:
             _LOGGER.error("Failed to set fan mode for climate %s: %s", climate_id, result.error_info)
             raise ServiceValidationError(translation_domain=DOMAIN, translation_key="climate_error_fan_mode")
 
-    async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str) -> None:
+    async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str, skip_ensure_off: bool = False) -> None:
         """Send multi-command IR packet and handle validation errors."""
-        await self._async_ensure_off_before_on(infrared_id, climate_id)
+        if not skip_ensure_off:
+            await self._async_ensure_off_before_on(infrared_id, climate_id)
         _LOGGER.debug("[%s] Sending combined IR packet -> Mode: %s, Temp: %s, Fan: %s", climate_id, hvac_mode, temperature, fan_mode)
         result = await self._api.async_send_multiple_command(
             infrared_id, climate_id, "1", tuya_mode(hvac_mode), tuya_temp(temperature), tuya_wind(fan_mode)

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime, timedelta, timezone
 import asyncio
-from typing import Any
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.exceptions import ServiceValidationError

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -109,7 +109,6 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         _LOGGER.debug("[%s] Executing combined power-on and fan mode configuration flow (%s)", climate_id, fan_mode)
 
         await self._send_power_command(infrared_id, climate_id, "1")
-        await self._send_temperature_command(infrared_id, climate_id, temperature)
         await self._send_fan_mode_command(infrared_id, climate_id, fan_mode)
 
         await self._async_force_update_data(climate_id, power=True, fan_mode=fan_mode)

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -64,6 +64,20 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
             if d.get(CONF_DEVICE_ID) == climate_id:
                 return d.get(CONF_COMPATIBILITY_OPTIONS, {}).get(option_key, default)
         return default
+
+    async def _async_ensure_off_before_on(self, infrared_id: str, climate_id: str) -> None:
+        """Ensure a power-off command is sent before any command that turns the device on."""
+        send_off_before_on = self._get_compatibility_option(
+            climate_id, CONF_SEND_OFF_BEFORE_ON, DEFAULT_SEND_OFF_BEFORE_ON
+        )
+        if not send_off_before_on:
+            return
+
+        current_data = self.data.get(climate_id)
+        if current_data is None or not current_data.power:
+            _LOGGER.debug("[%s] Device is off, sending power-off command before power-on", climate_id)
+            await self._api.async_send_command(infrared_id, climate_id, "power", "0")
+            await self._async_force_update_data(climate_id, power=True)
     
     # =========================================================================
     # PUBLIC ATOMIC COORDINATOR ACTIONS
@@ -132,13 +146,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
     async def _send_power_command(self, infrared_id: str, climate_id: str, state: str) -> None:
         """Send raw power command and handle validation errors."""
         if state == "1":
-            send_off_before_on = self._get_compatibility_option(
-                climate_id, CONF_SEND_OFF_BEFORE_ON, DEFAULT_SEND_OFF_BEFORE_ON
-            )
-            if send_off_before_on:
-                _LOGGER.debug("[%s] Sending power-off command before power-on", climate_id)
-                await self._api.async_send_command(infrared_id, climate_id, "power", "0")
-                await asyncio.sleep(1)
+            await self._async_ensure_off_before_on(infrared_id, climate_id)
 
         _LOGGER.debug("[%s] Sending IR command to turn %s climate", climate_id, "ON" if state == "1" else "OFF")
         result = await self._api.async_send_command(infrared_id, climate_id, "power", state)
@@ -149,6 +157,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 
     async def _send_temperature_command(self, infrared_id: str, climate_id: str, temperature: float) -> None:
         """Send raw temperature command and handle validation errors."""
+        await self._async_ensure_off_before_on(infrared_id, climate_id)
         _LOGGER.debug("[%s] Sending IR command to set temperature to %s°C", climate_id, temperature)
         result = await self._api.async_send_command(infrared_id, climate_id, "temp", tuya_temp(temperature))
         if not result.success:
@@ -157,6 +166,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 
     async def _send_fan_mode_command(self, infrared_id: str, climate_id: str, fan_mode: str) -> None:
         """Send raw fan mode command and handle validation errors."""
+        await self._async_ensure_off_before_on(infrared_id, climate_id)
         _LOGGER.debug("[%s] Sending IR command to set fan mode to %s", climate_id, fan_mode)
         result = await self._api.async_send_command(infrared_id, climate_id, "wind", tuya_wind(fan_mode))
         if not result.success:
@@ -165,6 +175,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 
     async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str) -> None:
         """Send multi-command IR packet and handle validation errors."""
+        await self._async_ensure_off_before_on(infrared_id, climate_id)
         _LOGGER.debug("[%s] Sending combined IR packet -> Mode: %s, Temp: %s, Fan: %s", climate_id, hvac_mode, temperature, fan_mode)
         result = await self._api.async_send_multiple_command(
             infrared_id, climate_id, "1", tuya_mode(hvac_mode), tuya_temp(temperature), tuya_wind(fan_mode)

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -143,10 +143,9 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
     # PRIVATE LOW-LEVEL COMMAND HELPERS
     # =========================================================================
 
-    async def _send_power_command(self, infrared_id: str, climate_id: str, state: str, skip_ensure_off: bool = False) -> None:
+    async def _send_power_command(self, infrared_id: str, climate_id: str, state: str) -> None:
         """Send raw power command and handle validation errors."""
-        if state == "1" and not skip_ensure_off:
-            await self._async_ensure_off_before_on(infrared_id, climate_id)
+        await self._async_ensure_off_before_on(infrared_id, climate_id)
 
         _LOGGER.debug("[%s] Sending IR command to turn %s climate", climate_id, "ON" if state == "1" else "OFF")
         result = await self._api.async_send_command(infrared_id, climate_id, "power", state)

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -72,11 +72,12 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 
         # Don't send power-off if the device is already considered ON in our cache
         current_state = self.data.get(climate_id)
-        if current_state and current_state.power:
+        if current_state and current_state.power == True:
             return
 
         _LOGGER.debug("[%s] Sending power-off command before power-on", climate_id)
         await self._api.async_send_command(infrared_id, climate_id, "power", "0")
+        await self._api.async_send_command(infrared_id, climate_id, "power", "1")
     
     # =========================================================================
     # PUBLIC ATOMIC COORDINATOR ACTIONS
@@ -115,7 +116,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         """Execute a combined flow: turn on the device via cloud and immediately set HVAC parameters, updating cache once."""
         _LOGGER.debug("[%s] Executing combined power-on and hvac mode configuration flow (%s)", climate_id, hvac_mode)
 
-        await self.async_turn_on(infrared_id, climate_id)
+        await self._send_power_command(infrared_id, climate_id, "1")
         await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode)
 
         await self._async_force_update_data(climate_id, power=True, hvac_mode=hvac_mode, temperature=temperature, fan_mode=fan_mode)
@@ -124,7 +125,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         """Execute a combined flow: turn on the device via cloud and immediately set temperature, updating cache once."""
         _LOGGER.debug("[%s] Executing combined power-on and temperature configuration flow (%s)", climate_id, temperature)
 
-        await self.async_turn_on(infrared_id, climate_id)
+        await self._send_power_command(infrared_id, climate_id, "1")
         await self._send_temperature_command(infrared_id, climate_id, temperature)
 
         await self._async_force_update_data(climate_id, power=True, temperature=temperature)
@@ -133,7 +134,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         """Execute a combined flow: turn on the device via cloud and immediately set fan mode, updating cache once."""
         _LOGGER.debug("[%s] Executing combined power-on and fan mode configuration flow (%s)", climate_id, fan_mode)
 
-        await self.async_turn_on(infrared_id, climate_id)
+        await self._send_power_command(infrared_id, climate_id, "1")
         await self._send_temperature_command(infrared_id, climate_id, temperature)
         await self._send_fan_mode_command(infrared_id, climate_id, fan_mode)
 
@@ -145,7 +146,8 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 
     async def _send_power_command(self, infrared_id: str, climate_id: str, state: str) -> None:
         """Send raw power command and handle validation errors."""
-        await self._async_ensure_off_before_on(infrared_id, climate_id)
+        if state == "1":
+            await self._async_ensure_off_before_on(infrared_id, climate_id)
 
         _LOGGER.debug("[%s] Sending IR command to turn %s climate", climate_id, "ON" if state == "1" else "OFF")
         result = await self._api.async_send_command(infrared_id, climate_id, "power", state)

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -241,7 +241,8 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 class TuyaSensorCoordinator(DataUpdateCoordinator[dict[str, TuyaSensorData]]):
     """Coordinator for physical Hub sensors, with unified Smart Polling logic."""
 
-    def __init__(self,
+    def __init__(
+        self,
         hass: HomeAssistant, 
         entry: ConfigEntry, 
         sensor_api: TuyaSensorAPI,

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -57,20 +57,23 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         """Check if the climate device is available in the fetched data."""
         return self.data and self.data.get(climate_id) is not None
 
-    def _get_compatibility_option(self, climate_id: str, option_key: str, default: Any) -> Any:
-        """Get compatibility option value for a specific climate device."""
-        climates = self.entry.options.get(DEVICE_TYPE_CLIMATES, [])
-        for d in climates:
-            if d.get(CONF_DEVICE_ID) == climate_id:
-                return d.get(CONF_COMPATIBILITY_OPTIONS, {}).get(option_key, default)
-        return default
-
     async def _async_ensure_off_before_on(self, infrared_id: str, climate_id: str) -> None:
         """Ensure a power-off command is sent before any command that turns the device on."""
-        send_off_before_on = self._get_compatibility_option(
-            climate_id, CONF_SEND_OFF_BEFORE_ON, DEFAULT_SEND_OFF_BEFORE_ON
-        )
+        climates = self.entry.options.get(DEVICE_TYPE_CLIMATES, [])
+        send_off_before_on = DEFAULT_SEND_OFF_BEFORE_ON
+        for d in climates:
+            if d.get(CONF_DEVICE_ID) == climate_id:
+                send_off_before_on = d.get(CONF_COMPATIBILITY_OPTIONS, {}).get(
+                    CONF_SEND_OFF_BEFORE_ON, DEFAULT_SEND_OFF_BEFORE_ON
+                )
+                break
+
         if not send_off_before_on:
+            return
+
+        # Don't send power-off if the device is already considered ON in our cache
+        current_state = self.data.get(climate_id)
+        if current_state and current_state.power:
             return
 
         _LOGGER.debug("[%s] Sending power-off command before power-on", climate_id)
@@ -114,7 +117,7 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         _LOGGER.debug("[%s] Executing combined power-on and hvac mode configuration flow (%s)", climate_id, hvac_mode)
         
         await self._send_power_command(infrared_id, climate_id, "1")
-        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode)
+        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode, skip_ensure_off=True)
         
         await self._async_force_update_data(climate_id, power=True, hvac_mode=hvac_mode, temperature=temperature, fan_mode=fan_mode)
 
@@ -168,8 +171,11 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
             _LOGGER.error("Failed to set fan mode for climate %s: %s", climate_id, result.error_info)
             raise ServiceValidationError(translation_domain=DOMAIN, translation_key="climate_error_fan_mode")
 
-    async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str) -> None:
+    async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str, skip_ensure_off: bool = False) -> None:
         """Send multi-command IR packet and handle validation errors."""
+        if not skip_ensure_off:
+            await self._async_ensure_off_before_on(infrared_id, climate_id)
+
         _LOGGER.debug("[%s] Sending combined IR packet -> Mode: %s, Temp: %s, Fan: %s", climate_id, hvac_mode, temperature, fan_mode)
         result = await self._api.async_send_multiple_command(
             infrared_id, climate_id, "1", tuya_mode(hvac_mode), tuya_temp(temperature), tuya_wind(fan_mode)

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -14,8 +14,7 @@ from .const import (
     UPDATE_TIMEOUT,
     CONF_DEVICE_ID,
     DEVICE_TYPE_CLIMATES,
-    DEVICE_TYPE_SENSORS,
-    CONF_COMPATIBILITY_OPTIONS
+    DEVICE_TYPE_SENSORS
 )
 from .helpers import tuya_temp, tuya_mode, tuya_wind
 from .api import TuyaClimateAPI, TuyaSensorAPI
@@ -263,7 +262,7 @@ class TuyaSensorCoordinator(DataUpdateCoordinator[dict[str, TuyaSensorData]]):
             if (now - last_ts) > threshold:
                 _LOGGER.debug("[%s] DPs code '%s' is outdated. Triggering cloud update.", device_id, code)
                 return True
-        
+
         _LOGGER.debug("[%s] All DPS codes are fresh. Skipping API refresh.", device_id)
         return False
 
@@ -281,10 +280,10 @@ class TuyaSensorCoordinator(DataUpdateCoordinator[dict[str, TuyaSensorData]]):
                 result = await self._api.async_fetch_all_data(devices_to_fetch)
                 if not result.success:
                     raise UpdateFailed(f"Tuya error: {result.error_info}")
-                
+
                 for dev_id, _ in result.data.items():
                     self._update_dps_timestamp(dev_id, TuyaSensorData.get_dps_codes())
-                
+
                 updated_data = self.data.copy()
                 updated_data.update(result.data)
                 return updated_data

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime, timedelta, timezone
 import asyncio
+from typing import Any
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.exceptions import ServiceValidationError
@@ -14,7 +15,10 @@ from .const import (
     UPDATE_TIMEOUT,
     CONF_DEVICE_ID,
     DEVICE_TYPE_CLIMATES,
-    DEVICE_TYPE_SENSORS
+    DEVICE_TYPE_SENSORS,
+    CONF_COMPATIBILITY_OPTIONS,
+    CONF_SEND_OFF_BEFORE_ON,
+    DEFAULT_SEND_OFF_BEFORE_ON,
 )
 from .helpers import tuya_temp, tuya_mode, tuya_wind
 from .api import TuyaClimateAPI, TuyaSensorAPI
@@ -52,6 +56,14 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
     def is_available(self, climate_id: str) -> bool:
         """Check if the climate device is available in the fetched data."""
         return self.data and self.data.get(climate_id) is not None
+
+    def _get_compatibility_option(self, climate_id: str, option_key: str, default: Any) -> Any:
+        """Get compatibility option value for a specific climate device."""
+        climates = self.entry.options.get(DEVICE_TYPE_CLIMATES, [])
+        for d in climates:
+            if d.get(CONF_DEVICE_ID) == climate_id:
+                return d.get(CONF_COMPATIBILITY_OPTIONS, {}).get(option_key, default)
+        return default
     
     # =========================================================================
     # PUBLIC ATOMIC COORDINATOR ACTIONS
@@ -119,6 +131,15 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 
     async def _send_power_command(self, infrared_id: str, climate_id: str, state: str) -> None:
         """Send raw power command and handle validation errors."""
+        if state == "1":
+            send_off_before_on = self._get_compatibility_option(
+                climate_id, CONF_SEND_OFF_BEFORE_ON, DEFAULT_SEND_OFF_BEFORE_ON
+            )
+            if send_off_before_on:
+                _LOGGER.debug("[%s] Sending power-off command before power-on", climate_id)
+                await self._api.async_send_command(infrared_id, climate_id, "power", "0")
+                await asyncio.sleep(1)
+
         _LOGGER.debug("[%s] Sending IR command to turn %s climate", climate_id, "ON" if state == "1" else "OFF")
         result = await self._api.async_send_command(infrared_id, climate_id, "power", state)
         if not result.success:

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -15,9 +15,7 @@ from .const import (
     CONF_DEVICE_ID,
     DEVICE_TYPE_CLIMATES,
     DEVICE_TYPE_SENSORS,
-    CONF_COMPATIBILITY_OPTIONS,
-    CONF_SEND_OFF_BEFORE_ON,
-    DEFAULT_SEND_OFF_BEFORE_ON,
+    CONF_COMPATIBILITY_OPTIONS
 )
 from .helpers import tuya_temp, tuya_mode, tuya_wind
 from .api import TuyaClimateAPI, TuyaSensorAPI
@@ -56,29 +54,6 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         """Check if the climate device is available in the fetched data."""
         return self.data and self.data.get(climate_id) is not None
 
-    async def _async_ensure_off_before_on(self, infrared_id: str, climate_id: str) -> None:
-        """Ensure a power-off command is sent before any command that turns the device on."""
-        climates = self.entry.options.get(DEVICE_TYPE_CLIMATES, [])
-        send_off_before_on = DEFAULT_SEND_OFF_BEFORE_ON
-        for d in climates:
-            if d.get(CONF_DEVICE_ID) == climate_id:
-                send_off_before_on = d.get(CONF_COMPATIBILITY_OPTIONS, {}).get(
-                    CONF_SEND_OFF_BEFORE_ON, DEFAULT_SEND_OFF_BEFORE_ON
-                )
-                break
-
-        if not send_off_before_on:
-            return
-
-        # Don't send power-off if the device is already considered ON in our cache
-        current_state = self.data.get(climate_id)
-        if current_state and current_state.power == True:
-            return
-
-        _LOGGER.debug("[%s] Sending power-off command before power-on", climate_id)
-        await self._api.async_send_command(infrared_id, climate_id, "power", "0")
-        await asyncio.sleep(0.5)
-    
     # =========================================================================
     # PUBLIC ATOMIC COORDINATOR ACTIONS
     # =========================================================================
@@ -146,9 +121,6 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 
     async def _send_power_command(self, infrared_id: str, climate_id: str, state: str) -> None:
         """Send raw power command and handle validation errors."""
-        if state == "1":
-            await self._async_ensure_off_before_on(infrared_id, climate_id)
-
         _LOGGER.debug("[%s] Sending IR command to turn %s climate", climate_id, "ON" if state == "1" else "OFF")
         result = await self._api.async_send_command(infrared_id, climate_id, "power", state)
         if not result.success:
@@ -174,8 +146,6 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
 
     async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str) -> None:
         """Send multi-command IR packet and handle validation errors."""
-        await self._async_ensure_off_before_on(infrared_id, climate_id)
-
         _LOGGER.debug("[%s] Sending combined IR packet -> Mode: %s, Temp: %s, Fan: %s", climate_id, hvac_mode, temperature, fan_mode)
         result = await self._api.async_send_multiple_command(
             infrared_id, climate_id, "1", tuya_mode(hvac_mode), tuya_temp(temperature), tuya_wind(fan_mode)

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -114,17 +114,17 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
     async def async_turn_on_with_hvac_mode(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str):
         """Execute a combined flow: turn on the device via cloud and immediately set HVAC parameters, updating cache once."""
         _LOGGER.debug("[%s] Executing combined power-on and hvac mode configuration flow (%s)", climate_id, hvac_mode)
-        
-        await self._send_power_command(infrared_id, climate_id, "1")
-        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode, skip_ensure_off=True)
-        
+
+        await self.async_turn_on(infrared_id, climate_id)
+        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode)
+
         await self._async_force_update_data(climate_id, power=True, hvac_mode=hvac_mode, temperature=temperature, fan_mode=fan_mode)
 
     async def async_turn_on_with_temperature(self, infrared_id: str, climate_id: str, temperature: float):
         """Execute a combined flow: turn on the device via cloud and immediately set temperature, updating cache once."""
         _LOGGER.debug("[%s] Executing combined power-on and temperature configuration flow (%s)", climate_id, temperature)
 
-        await self._send_power_command(infrared_id, climate_id, "1")
+        await self.async_turn_on(infrared_id, climate_id)
         await self._send_temperature_command(infrared_id, climate_id, temperature)
 
         await self._async_force_update_data(climate_id, power=True, temperature=temperature)
@@ -133,7 +133,8 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         """Execute a combined flow: turn on the device via cloud and immediately set fan mode, updating cache once."""
         _LOGGER.debug("[%s] Executing combined power-on and fan mode configuration flow (%s)", climate_id, fan_mode)
 
-        await self._send_power_command(infrared_id, climate_id, "1")
+        await self.async_turn_on(infrared_id, climate_id)
+        await self._send_temperature_command(infrared_id, climate_id, temperature)
         await self._send_fan_mode_command(infrared_id, climate_id, fan_mode)
 
         await self._async_force_update_data(climate_id, power=True, fan_mode=fan_mode)
@@ -170,10 +171,9 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
             _LOGGER.error("Failed to set fan mode for climate %s: %s", climate_id, result.error_info)
             raise ServiceValidationError(translation_domain=DOMAIN, translation_key="climate_error_fan_mode")
 
-    async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str, skip_ensure_off: bool = False) -> None:
+    async def _send_combined_command(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str) -> None:
         """Send multi-command IR packet and handle validation errors."""
-        if not skip_ensure_off:
-            await self._async_ensure_off_before_on(infrared_id, climate_id)
+        await self._async_ensure_off_before_on(infrared_id, climate_id)
 
         _LOGGER.debug("[%s] Sending combined IR packet -> Mode: %s, Temp: %s, Fan: %s", climate_id, hvac_mode, temperature, fan_mode)
         result = await self._api.async_send_multiple_command(

--- a/custom_components/tuya_smart_ir_ac/coordinator.py
+++ b/custom_components/tuya_smart_ir_ac/coordinator.py
@@ -90,19 +90,19 @@ class TuyaClimateCoordinator(DataUpdateCoordinator[dict[str, TuyaClimateData]]):
         await self._send_power_command(infrared_id, climate_id, "0")
         await self._async_force_update_data(climate_id, power=False)
 
-    async def async_set_temperature(self, infrared_id: str, climate_id: str, temperature: float):
+    async def async_set_temperature(self, infrared_id: str, climate_id: str, temperature: float, skip_ensure_off: bool = False):
         """Send IR command to set target temperature and update local cache."""
-        await self._send_temperature_command(infrared_id, climate_id, temperature)
+        await self._send_temperature_command(infrared_id, climate_id, temperature, skip_ensure_off=skip_ensure_off)
         await self._async_force_update_data(climate_id, power=True, temperature=temperature)
 
-    async def async_set_fan_mode(self, infrared_id: str, climate_id: str, fan_mode: str):
+    async def async_set_fan_mode(self, infrared_id: str, climate_id: str, fan_mode: str, skip_ensure_off: bool = False):
         """Send IR command to set fan mode and update local cache."""
-        await self._send_fan_mode_command(infrared_id, climate_id, fan_mode)
+        await self._send_fan_mode_command(infrared_id, climate_id, fan_mode, skip_ensure_off=skip_ensure_off)
         await self._async_force_update_data(climate_id, power=True, fan_mode=fan_mode)
 
-    async def async_set_hvac_mode(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str):
+    async def async_set_hvac_mode(self, infrared_id: str, climate_id: str, hvac_mode: HVACMode, temperature: float, fan_mode: str, skip_ensure_off: bool = False):
         """Send a combined multi-command IR packet (Mode, Temp, Fan) and update local cache."""
-        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode)
+        await self._send_combined_command(infrared_id, climate_id, hvac_mode, temperature, fan_mode, skip_ensure_off=skip_ensure_off)
         await self._async_force_update_data(climate_id, power=True, hvac_mode=hvac_mode, temperature=temperature, fan_mode=fan_mode)
 
     # =========================================================================

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -451,9 +451,9 @@ class TuyaClimateEntity:
             return
 
         domain = self._custom_power_on.split(".", 1)[0]
-        if domain == Platform.SCENE:
+        if domain == "scene":
             service = "turn_on"
-        elif domain == Platform.BUTTON:
+        elif domain == "button":
             service = "press"
         else:
             service = "turn_on"

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -72,7 +72,7 @@ class TuyaClimateEntity:
     def __init__(self, config_data: dict[str, Any], runtime_data: RuntimeData, sub_entity_type: str | None = None) -> None:
         """Initialize core configuration boundaries and user preferences."""
         self._runtime_data = runtime_data
-        
+
         self._infrared_id = config_data.get(CONF_INFRARED_ID)
         self._climate_id = config_data.get(CONF_DEVICE_ID)
         self._name = config_data.get(CONF_NAME)
@@ -253,7 +253,7 @@ class TuyaClimateEntity:
         sensor_state = self.hass.states.get(self._temperature_sensor)
         if not valid_sensor_state(sensor_state):
             return None
-        
+
         value = convert_to_float(sensor_state.state)
         if value is None:
             return None
@@ -276,7 +276,7 @@ class TuyaClimateEntity:
         return convert_to_float(sensor_state.state)
 
     def get_preset_modes(self) -> str:
-        """Return the list of available preset modes based on current HVAC mode."""    
+        """Return the list of available preset modes based on current HVAC mode."""
         global_presets = self._runtime_data.global_presets
 
         if not global_presets or not self._preset_modes:
@@ -294,9 +294,9 @@ class TuyaClimateEntity:
                 available_presets.append(preset_name)
 
         return available_presets
-    
+
     def get_preset_mode(self) -> str:
-        """Return the active preset matching real-time device configurations."""        
+        """Return the active preset matching real-time device configurations."""
         if self._current_hvac_mode is HVACMode.OFF:
             return PRESET_NONE
 
@@ -407,7 +407,7 @@ class TuyaClimateEntity:
 
     async def async_handle_set_preset_mode(self, preset_mode: str) -> None:
         """Set preset mode for the climate device."""
-        
+
         if preset_mode == PRESET_NONE:
             return
 
@@ -480,11 +480,11 @@ class TuyaSensorEntity:
         """Initialize core reporting identities and linked environmental device metadata."""
         self._runtime_data = runtime_data
         self._sensor_type = sensor_type
-        
+
         self._device_id = config_data.get(CONF_DEVICE_ID)
         self._name = config_data.get(CONF_NAME)
         self._unit_of_measurement = config_data.get(CONF_TEMP_UNIT, UnitOfTemperature.CELSIUS)
-        
+
         self._attr_unique_id = f"{self._device_id}_{self._sensor_type}"
         self._attr_device_info = DeviceInfo(
             name=self._name,
@@ -497,24 +497,24 @@ class TuyaSensorEntity:
     def available(self) -> bool:
         """Check environmental sensor availability using the coordinator data cache mapping."""
         return self.coordinator.is_available(self._device_id)
-    
+
     @property
     def _device_sensor_data(self) -> TuyaSensorData | None:
         """Centralized accessor to safely extract the current device's data from the coordinator cache."""
         if self.coordinator.data:
             return self.coordinator.data.get(self._device_id)
         return TuyaSensorData()
-    
+
     @property
     def _current_temperature(self) -> float:
         """Centralized accessor to safely fetch the current temperature."""
         return self._device_sensor_data.temp_current
-    
+
     @property
     def _current_humidity(self) -> float:
         """Centralized accessor to safely fetch the current humidity."""
         return self._device_sensor_data.humidity_value
-    
+
     @property
     def _battery_state(self) -> float:
         """Centralized accessor to safely fetch the battery state."""

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -226,7 +226,7 @@ class TuyaClimateEntity:
     @property
     def _is_custom_power_on_scene(self) -> bool:
         """Return True if the custom power-on action is a scene."""
-        return bool(self._custom_power_on and self._custom_power_on.startswith("scene."))
+        return bool(self._custom_power_on and self._custom_power_on.startswith(f"{Platform.SCENE}."))
 
     def get_power_on(self, power_on_setting: str, hvac_mode_previous_state: HVACMode) -> bool:
         """Match hardware policy definitions against current machine states to verify power requirements."""

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -207,14 +207,20 @@ class TuyaClimateEntity:
 
     def get_hvac_power_on(self, hvac_mode_previous_state: HVACMode) -> bool:
         """Check whether an explicit power command must precede a mode alteration."""
+        if self._custom_power_on and hvac_mode_previous_state is HVACMode.OFF:
+            return True
         return self.get_power_on(self._hvac_power_on, hvac_mode_previous_state)
 
     def get_temp_power_on(self, hvac_mode_previous_state: HVACMode) -> bool:
         """Check whether an explicit power command must precede a temperature shift."""
+        if self._custom_power_on and hvac_mode_previous_state is HVACMode.OFF:
+            return True
         return self.get_power_on(self._temp_power_on, hvac_mode_previous_state)
 
     def get_fan_power_on(self, hvac_mode_previous_state: HVACMode) -> bool:
         """Check whether an explicit power command must precede a ventilation shift."""
+        if self._custom_power_on and hvac_mode_previous_state is HVACMode.OFF:
+            return True
         return self.get_power_on(self._fan_power_on, hvac_mode_previous_state)
 
     @property
@@ -333,7 +339,7 @@ class TuyaClimateEntity:
             await self._async_trigger_custom_on_if_configured()
             if self._is_custom_power_on_scene:
                 await self.coordinator.async_set_hvac_mode(
-                    self._infrared_id, self._climate_id, hvac_mode, temperature, fan_mode
+                    self._infrared_id, self._climate_id, hvac_mode, temperature, fan_mode, skip_ensure_off=True
                 )
             else:
                 await self.coordinator.async_turn_on_with_hvac_mode(
@@ -356,7 +362,7 @@ class TuyaClimateEntity:
                     await self._async_trigger_custom_on_if_configured()
                     if self._is_custom_power_on_scene:
                         await self.coordinator.async_set_hvac_mode(
-                            self._infrared_id, self._climate_id, hvac_mode, value, fan_mode
+                            self._infrared_id, self._climate_id, hvac_mode, value, fan_mode, skip_ensure_off=True
                         )
                     else:
                         await self.coordinator.async_turn_on_with_hvac_mode(
@@ -371,7 +377,7 @@ class TuyaClimateEntity:
                 await self._async_trigger_custom_on_if_configured()
                 if self._is_custom_power_on_scene:
                     await self.coordinator.async_set_temperature(
-                        self._infrared_id, self._climate_id, value
+                        self._infrared_id, self._climate_id, value, skip_ensure_off=True
                     )
                 else:
                     await self.coordinator.async_turn_on_with_temperature(
@@ -388,7 +394,7 @@ class TuyaClimateEntity:
             await self._async_trigger_custom_on_if_configured()
             if self._is_custom_power_on_scene:
                 await self.coordinator.async_set_fan_mode(
-                    self._infrared_id, self._climate_id, fan_mode
+                    self._infrared_id, self._climate_id, fan_mode, skip_ensure_off=True
                 )
             else:
                 await self.coordinator.async_turn_on_with_fan_mode(
@@ -426,7 +432,8 @@ class TuyaClimateEntity:
                         self._climate_id, 
                         target_mode,
                         target_temp, 
-                        target_fan
+                        target_fan,
+                        skip_ensure_off=True
                     )
                 else:
                     await self.coordinator.async_turn_on_with_hvac_mode(

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -409,13 +409,21 @@ class TuyaClimateEntity:
                 )
 
     async def _async_trigger_custom_on_if_configured(self) -> None:
-        """Trigger the custom hardware alternative power-on button if configured."""
+        """Trigger the custom hardware alternative power-on button or scene if configured."""
         if not self._custom_power_on:
             return
 
+        domain = self._custom_power_on.split(".", 1)[0]
+        if domain == Platform.SCENE:
+            service = "turn_on"
+        elif domain == Platform.BUTTON:
+            service = "press"
+        else:
+            service = "turn_on"
+
         await self.hass.services.async_call(
-            domain=Platform.BUTTON,
-            service="press",
+            domain=domain,
+            service=service,
             service_data={"entity_id": self._custom_power_on},
             blocking=True
         )

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -339,7 +339,7 @@ class TuyaClimateEntity:
             await self._async_trigger_custom_on_if_configured()
             if self._is_custom_power_on_scene:
                 await self.coordinator.async_set_hvac_mode(
-                    self._infrared_id, self._climate_id, hvac_mode, temperature, fan_mode, skip_ensure_off=True
+                    self._infrared_id, self._climate_id, hvac_mode, temperature, fan_mode
                 )
             else:
                 await self.coordinator.async_turn_on_with_hvac_mode(
@@ -362,7 +362,7 @@ class TuyaClimateEntity:
                     await self._async_trigger_custom_on_if_configured()
                     if self._is_custom_power_on_scene:
                         await self.coordinator.async_set_hvac_mode(
-                            self._infrared_id, self._climate_id, hvac_mode, value, fan_mode, skip_ensure_off=True
+                            self._infrared_id, self._climate_id, hvac_mode, value, fan_mode
                         )
                     else:
                         await self.coordinator.async_turn_on_with_hvac_mode(
@@ -377,7 +377,7 @@ class TuyaClimateEntity:
                 await self._async_trigger_custom_on_if_configured()
                 if self._is_custom_power_on_scene:
                     await self.coordinator.async_set_temperature(
-                        self._infrared_id, self._climate_id, value, skip_ensure_off=True
+                        self._infrared_id, self._climate_id, value
                     )
                 else:
                     await self.coordinator.async_turn_on_with_temperature(
@@ -394,7 +394,7 @@ class TuyaClimateEntity:
             await self._async_trigger_custom_on_if_configured()
             if self._is_custom_power_on_scene:
                 await self.coordinator.async_set_fan_mode(
-                    self._infrared_id, self._climate_id, fan_mode, skip_ensure_off=True
+                    self._infrared_id, self._climate_id, fan_mode
                 )
             else:
                 await self.coordinator.async_turn_on_with_fan_mode(
@@ -432,8 +432,7 @@ class TuyaClimateEntity:
                         self._climate_id, 
                         target_mode,
                         target_temp, 
-                        target_fan,
-                        skip_ensure_off=True
+                        target_fan
                     )
                 else:
                     await self.coordinator.async_turn_on_with_hvac_mode(

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -456,7 +456,8 @@ class TuyaClimateEntity:
         elif domain == "button":
             service = "press"
         else:
-            service = "turn_on"
+            _LOGGER.error("[%s] Unsupported custom power-on entity domain: %s", self._climate_id, domain)
+            return
 
         await self.hass.services.async_call(
             domain=domain,

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -217,6 +217,11 @@ class TuyaClimateEntity:
         """Check whether an explicit power command must precede a ventilation shift."""
         return self.get_power_on(self._fan_power_on, hvac_mode_previous_state)
 
+    @property
+    def _is_custom_power_on_scene(self) -> bool:
+        """Return True if the custom power-on action is a scene."""
+        return bool(self._custom_power_on and self._custom_power_on.startswith("scene."))
+
     def get_power_on(self, power_on_setting: str, hvac_mode_previous_state: HVACMode) -> bool:
         """Match hardware policy definitions against current machine states to verify power requirements."""
         if power_on_setting == POWER_ON_NEVER:
@@ -306,7 +311,10 @@ class TuyaClimateEntity:
     async def async_handle_turn_on(self) -> None:
         """Turn on the climate device power via coordinator service."""
         await self._async_trigger_custom_on_if_configured()
-        await self.coordinator.async_turn_on(self._infrared_id, self._climate_id)
+        if self._is_custom_power_on_scene:
+            await self.coordinator._async_force_update_data(self._climate_id, power=True)
+        else:
+            await self.coordinator.async_turn_on(self._infrared_id, self._climate_id)
 
     async def async_handle_turn_off(self) -> None:
         """Turn off the climate device power via coordinator service."""
@@ -323,9 +331,14 @@ class TuyaClimateEntity:
 
         if self.get_hvac_power_on(self._current_hvac_mode):
             await self._async_trigger_custom_on_if_configured()
-            await self.coordinator.async_turn_on_with_hvac_mode(
-                self._infrared_id, self._climate_id, hvac_mode, temperature, fan_mode
-            )
+            if self._is_custom_power_on_scene:
+                await self.coordinator.async_set_hvac_mode(
+                    self._infrared_id, self._climate_id, hvac_mode, temperature, fan_mode
+                )
+            else:
+                await self.coordinator.async_turn_on_with_hvac_mode(
+                    self._infrared_id, self._climate_id, hvac_mode, temperature, fan_mode
+                )
         else:
             await self.coordinator.async_set_hvac_mode(
                 self._infrared_id, self._climate_id, hvac_mode, temperature, fan_mode
@@ -341,9 +354,14 @@ class TuyaClimateEntity:
 
                 if self.get_hvac_power_on(self._current_hvac_mode):
                     await self._async_trigger_custom_on_if_configured()
-                    await self.coordinator.async_turn_on_with_hvac_mode(
-                        self._infrared_id, self._climate_id, hvac_mode, value, fan_mode
-                    )
+                    if self._is_custom_power_on_scene:
+                        await self.coordinator.async_set_hvac_mode(
+                            self._infrared_id, self._climate_id, hvac_mode, value, fan_mode
+                        )
+                    else:
+                        await self.coordinator.async_turn_on_with_hvac_mode(
+                            self._infrared_id, self._climate_id, hvac_mode, value, fan_mode
+                        )
                 else:
                     await self.coordinator.async_set_hvac_mode(
                         self._infrared_id, self._climate_id, hvac_mode, value, fan_mode
@@ -351,9 +369,14 @@ class TuyaClimateEntity:
         else:
             if self.get_temp_power_on(self._current_hvac_mode):
                 await self._async_trigger_custom_on_if_configured()
-                await self.coordinator.async_turn_on_with_temperature(
-                    self._infrared_id, self._climate_id, value
-                )
+                if self._is_custom_power_on_scene:
+                    await self.coordinator.async_set_temperature(
+                        self._infrared_id, self._climate_id, value
+                    )
+                else:
+                    await self.coordinator.async_turn_on_with_temperature(
+                        self._infrared_id, self._climate_id, value
+                    )
             else:
                 await self.coordinator.async_set_temperature(
                     self._infrared_id, self._climate_id, value
@@ -363,9 +386,14 @@ class TuyaClimateEntity:
         """Set fan mode for the climate device via coordinator service."""
         if self.get_fan_power_on(self._current_hvac_mode):
             await self._async_trigger_custom_on_if_configured()
-            await self.coordinator.async_turn_on_with_fan_mode(
-                self._infrared_id, self._climate_id, fan_mode
-            )
+            if self._is_custom_power_on_scene:
+                await self.coordinator.async_set_fan_mode(
+                    self._infrared_id, self._climate_id, fan_mode
+                )
+            else:
+                await self.coordinator.async_turn_on_with_fan_mode(
+                    self._infrared_id, self._climate_id, fan_mode
+                )
         else:
             await self.coordinator.async_set_fan_mode(
                 self._infrared_id, self._climate_id, fan_mode
@@ -392,13 +420,22 @@ class TuyaClimateEntity:
 
             if self.get_hvac_power_on(self._current_hvac_mode):
                 await self._async_trigger_custom_on_if_configured()
-                await self.coordinator.async_turn_on_with_hvac_mode(
-                    self._infrared_id, 
-                    self._climate_id, 
-                    target_mode,
-                    target_temp, 
-                    target_fan
-                )
+                if self._is_custom_power_on_scene:
+                    await self.coordinator.async_set_hvac_mode(
+                        self._infrared_id, 
+                        self._climate_id, 
+                        target_mode,
+                        target_temp, 
+                        target_fan
+                    )
+                else:
+                    await self.coordinator.async_turn_on_with_hvac_mode(
+                        self._infrared_id, 
+                        self._climate_id, 
+                        target_mode,
+                        target_temp, 
+                        target_fan
+                    )
             else:
                 await self.coordinator.async_set_hvac_mode(
                     self._infrared_id, 

--- a/custom_components/tuya_smart_ir_ac/entity.py
+++ b/custom_components/tuya_smart_ir_ac/entity.py
@@ -457,9 +457,9 @@ class TuyaClimateEntity:
             return
 
         domain = self._custom_power_on.split(".", 1)[0]
-        if domain == "scene":
+        if domain == Platform.SCENE:
             service = "turn_on"
-        elif domain == "button":
+        elif domain == Platform.BUTTON:
             service = "press"
         else:
             _LOGGER.error("[%s] Unsupported custom power-on entity domain: %s", self._climate_id, domain)

--- a/custom_components/tuya_smart_ir_ac/manifest.json
+++ b/custom_components/tuya_smart_ir_ac/manifest.json
@@ -1,12 +1,12 @@
 {
    "domain": "tuya_smart_ir_ac",
    "name": "Tuya Smart IR AC",
-   "codeowners": ["@EnzoD86"],
+   "codeowners": ["@cornguo"],
    "config_flow": true,
-   "documentation": "https://github.com/EnzoD86/tuya-smart-ir-ac",
+   "documentation": "https://github.com/cornguo/tuya-smart-ir-ac",
    "integration_type": "hub",
    "iot_class": "cloud_polling",
-   "issue_tracker": "https://github.com/EnzoD86/tuya-smart-ir-ac/issues",
+   "issue_tracker": "https://github.com/cornguo/tuya-smart-ir-ac/issues",
    "requirements": [],
    "version": "2026.6.4"
 }

--- a/custom_components/tuya_smart_ir_ac/manifest.json
+++ b/custom_components/tuya_smart_ir_ac/manifest.json
@@ -1,12 +1,12 @@
 {
    "domain": "tuya_smart_ir_ac",
    "name": "Tuya Smart IR AC",
-   "codeowners": ["@cornguo"],
+   "codeowners": ["@EnzoD86"],
    "config_flow": true,
-   "documentation": "https://github.com/cornguo/tuya-smart-ir-ac",
+   "documentation": "https://github.com/EnzoD86/tuya-smart-ir-ac",
    "integration_type": "hub",
    "iot_class": "cloud_polling",
-   "issue_tracker": "https://github.com/cornguo/tuya-smart-ir-ac/issues",
+   "issue_tracker": "https://github.com/EnzoD86/tuya-smart-ir-ac/issues",
    "requirements": [],
    "version": "2026.6.4"
 }

--- a/custom_components/tuya_smart_ir_ac/translations/en.json
+++ b/custom_components/tuya_smart_ir_ac/translations/en.json
@@ -212,7 +212,6 @@
               "fan_power_on": "Force power on when setting fan speed",
               "dry_min_temp": "Set minimum temperature in dry mode",
               "dry_min_fan": "Set minimum fan speed in dry mode",
-              "send_off_before_on": "Send power-off command before power-on",
               "custom_power_on": "Custom power-on button or scene (ONLY if standard power-on fails)"
             }
           }
@@ -242,7 +241,6 @@
               "fan_power_on": "Force power on when setting fan speed",
               "dry_min_temp": "Set minimum temperature in dry mode",
               "dry_min_fan": "Set minimum fan speed in dry mode",
-              "send_off_before_on": "Send power-off command before power-on",
               "custom_power_on": "Custom power-on button or scene (ONLY if standard power-on fails)"
             }
           }

--- a/custom_components/tuya_smart_ir_ac/translations/en.json
+++ b/custom_components/tuya_smart_ir_ac/translations/en.json
@@ -212,6 +212,7 @@
               "fan_power_on": "Force power on when setting fan speed",
               "dry_min_temp": "Set minimum temperature in dry mode",
               "dry_min_fan": "Set minimum fan speed in dry mode",
+              "send_off_before_on": "Send power-off command before power-on",
               "custom_power_on": "Custom power-on button or scene (ONLY if standard power-on fails)"
             }
           }
@@ -241,6 +242,7 @@
               "fan_power_on": "Force power on when setting fan speed",
               "dry_min_temp": "Set minimum temperature in dry mode",
               "dry_min_fan": "Set minimum fan speed in dry mode",
+              "send_off_before_on": "Send power-off command before power-on",
               "custom_power_on": "Custom power-on button or scene (ONLY if standard power-on fails)"
             }
           }

--- a/custom_components/tuya_smart_ir_ac/translations/en.json
+++ b/custom_components/tuya_smart_ir_ac/translations/en.json
@@ -212,7 +212,7 @@
               "fan_power_on": "Force power on when setting fan speed",
               "dry_min_temp": "Set minimum temperature in dry mode",
               "dry_min_fan": "Set minimum fan speed in dry mode",
-              "custom_power_on": "Custom power-on button (ONLY if standard power-on fails)"
+              "custom_power_on": "Custom power-on button or scene (ONLY if standard power-on fails)"
             }
           }
         }
@@ -241,7 +241,7 @@
               "fan_power_on": "Force power on when setting fan speed",
               "dry_min_temp": "Set minimum temperature in dry mode",
               "dry_min_fan": "Set minimum fan speed in dry mode",
-              "custom_power_on": "Custom power-on button (ONLY if standard power-on fails)"
+              "custom_power_on": "Custom power-on button or scene (ONLY if standard power-on fails)"
             }
           }
         }

--- a/custom_components/tuya_smart_ir_ac/translations/zh-Hant.json
+++ b/custom_components/tuya_smart_ir_ac/translations/zh-Hant.json
@@ -212,7 +212,6 @@
               "fan_power_on": "設定風速時強制開機",
               "dry_min_temp": "設定除濕模式的最低溫度",
               "dry_min_fan": "設定除濕模式的最低風速",
-              "send_off_before_on": "開機前傳送關機指令",
               "custom_power_on": "自訂開機按鍵或場景（僅在標準開機失敗時使用）"
             }
           }
@@ -242,7 +241,6 @@
               "fan_power_on": "設定風速時強制開機",
               "dry_min_temp": "設定除濕模式的最低溫度",
               "dry_min_fan": "設定除濕模式的最低風速",
-              "send_off_before_on": "開機前傳送關機指令",
               "custom_power_on": "自訂開機按鍵或場景（僅在標準開機失敗時使用）"
             }
           }

--- a/custom_components/tuya_smart_ir_ac/translations/zh-Hant.json
+++ b/custom_components/tuya_smart_ir_ac/translations/zh-Hant.json
@@ -1,0 +1,343 @@
+{
+  "entity": {
+    "number": {
+      "hvac_mode_auto": {
+        "name": "自動"
+      },
+      "hvac_mode_cool": {
+        "name": "冷氣"
+      },
+      "hvac_mode_heat": {
+        "name": "暖氣"
+      }
+    },
+    "select": {
+      "hvac_mode": {
+        "name": "空調模式",
+        "state": {
+          "auto": "自動",
+          "cool": "冷氣",
+          "heat": "暖氣",
+          "dry": "除濕",
+          "fan_only": "送風",
+          "off": "關閉"
+        }
+      },
+      "fan_mode": {
+        "name": "風速",
+        "state": {
+          "auto": "自動",
+          "low": "低",
+          "medium": "中",
+          "high": "高"
+        }
+      }
+    }
+  },
+  "selector": {
+    "countries": {
+      "options": {
+        "eu": "歐洲",
+        "us": "美洲",
+        "in": "印度",
+        "cn": "中國",
+        "sg": "新加坡"
+      }
+    },
+    "device_type": {
+      "options": {
+        "climate": "冷氣機",
+        "generic": "通用設備",
+        "sensor": "溫濕度感測器"
+      }
+    },
+    "hvac_modes": {
+      "options": {
+        "auto": "自動",
+        "cool": "冷氣",
+        "heat": "暖氣",
+        "dry": "除濕",
+        "fan_only": "送風",
+        "off": "關閉"
+      }
+    },
+    "fan_modes": {
+      "options": {
+        "auto": "自動",
+        "low": "低",
+        "medium": "中",
+        "high": "高"
+      }
+    },
+    "presets_modes": {
+      "options": {
+        "home": "在家",
+        "sleep": "睡眠",
+        "eco": "節能",
+        "comfort": "舒適",
+        "away": "離家"
+      }
+    },
+    "hvac_presets": {
+      "options": {
+        "fan_hvac_mode": "預設風速",
+        "temp_hvac_mode": "預設溫度"
+      }
+    },
+    "optional_entities": {
+      "options": {
+        "current_temperature": "溫度感測器",
+        "current_humidity": "濕度感測器",
+        "hvac_mode": "空調控制",
+        "fan_mode": "風速控制",
+        "temp_setpoint": "溫度控制"
+      }
+    },
+    "power_on_modes": {
+      "options": {
+        "never": "從不",
+        "always": "總是",
+        "only_off": "僅在關閉時（不推薦）"
+      }
+    }
+  },
+  "config": {
+    "step": {
+      "hub_settings": {
+        "title": "網關設定",
+        "description": "設定存取憑證與網關選項。",
+        "data": {
+          "access_id": "涂鴉 Access ID",
+          "access_secret": "涂鴉 Access Secret",
+          "country": "涂鴉國家 API",
+          "enable_pulsar": "啟用涂鴉 Pulsar 串流",
+          "climate_update_interval": "冷氣更新間隔",
+          "sensor_update_interval": "溫濕度更新間隔"
+        }
+      }
+    },
+    "error": {
+      "cannot_change_access_id": "無法修改現有網關的 Access ID。",
+      "cannot_connect_to_tuya": "連線涂鴉伺服器失敗。請檢查您的網路。",
+      "invalid_auth": "驗證失敗：無效的 Access ID 或 Access Secret。",
+      "invalid_data_center": "驗證失敗：無效的數據中心。"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "涂鴉智慧紅外線設定",
+        "menu_options": {
+          "device_management": "設備管理",
+          "presets_management": "全域預設管理",
+          "hub_settings": "網關設定"
+        }
+      },
+      "device_management": {
+        "title": "設備管理",
+        "menu_options": {
+          "climate_management": "冷氣管理",
+          "generic_management": "通用設備管理",
+          "sensor_management": "溫濕度感測器管理",
+          "back_to_init": "⬅️ 返回主選單"
+        }
+      },
+      "presets_management": {
+        "title": "全域預設管理",
+        "description": "選擇要設定的預設與模式。",
+        "data": {
+          "preset": "預設",
+          "hvac_mode": "模式"
+        }
+      },
+      "preset_configure": {
+        "title": "預設設定",
+        "description": "設定此預設的溫度與風速模式。",
+        "data": {
+          "preset": "已選擇的預設",
+          "hvac_mode": "已選擇的模式",
+          "temp": "目標溫度",
+          "fan": "風速"
+        }
+      },
+      "climate_management": {
+        "title": "冷氣管理",
+        "menu_options": {
+          "add_climate": "新增冷氣",
+          "edit_climate": "編輯現有冷氣",
+          "remove_climate": "移除現有冷氣",
+          "back_to_devices": "⬅️ 返回設備管理"
+        }
+      },
+      "generic_management": {
+        "title": "通用設備管理",
+        "menu_options": {
+          "add_generic": "新增通用設備",
+          "remove_generic": "移除現有通用設備",
+          "back_to_devices": "⬅️ 返回設備管理"
+        }
+      },
+      "sensor_management": {
+        "title": "溫濕度感測器管理",
+        "menu_options": {
+          "add_sensor": "新增溫濕度感測器",
+          "remove_sensor": "移除現有溫濕度感測器",
+          "back_to_devices": "⬅️ 返回設備管理"
+        }
+      },
+      "add_climate": {
+        "title": "新增冷氣",
+        "description": "輸入資料以配對新冷氣。",
+        "data": {
+          "infrared_id": "紅外線網關 ID",
+          "device_id": "冷氣 ID",
+          "name": "冷氣名稱",
+          "temperature_sensor": "溫度感測器",
+          "humidity_sensor": "濕度感測器",
+          "min_temp": "最低溫度",
+          "max_temp": "最高溫度",
+          "temp_step": "溫度步進",
+          "hvac_modes": "支援的空調模式",
+          "fan_modes": "支援的風速模式",
+          "preset_modes": "支援的預設模式",
+          "hvac_presets": "空調自動預設",
+          "optional_entities": "選用實體"
+        },
+        "sections": {
+          "compatibility_options": {
+            "name": "相容性選項",
+            "data": {
+              "hvac_power_on": "設定空調模式時強制開機",
+              "temp_power_on": "設定溫度時強制開機",
+              "fan_power_on": "設定風速時強制開機",
+              "dry_min_temp": "設定除濕模式的最低溫度",
+              "dry_min_fan": "設定除濕模式的最低風速",
+              "send_off_before_on": "開機前傳送關機指令",
+              "custom_power_on": "自訂開機按鍵或場景（僅在標準開機失敗時使用）"
+            }
+          }
+        }
+      },
+      "edit_climate": {
+        "title": "編輯冷氣",
+        "description": "更新冷氣的選項。",
+        "data": {
+          "temperature_sensor": "溫度感測器",
+          "humidity_sensor": "濕度感測器",
+          "min_temp": "最低溫度",
+          "max_temp": "最高溫度",
+          "temp_step": "溫度步進",
+          "hvac_modes": "支援的空調模式",
+          "fan_modes": "支援的風速模式",
+          "preset_modes": "支援的預設模式",
+          "hvac_presets": "空調自動預設",
+          "optional_entities": "選用實體"
+        },
+        "sections": {
+          "compatibility_options": {
+            "name": "相容性選項",
+            "data": {
+              "hvac_power_on": "設定空調模式時強制開機",
+              "temp_power_on": "設定溫度時強制開機",
+              "fan_power_on": "設定風速時強制開機",
+              "dry_min_temp": "設定除濕模式的最低溫度",
+              "dry_min_fan": "設定除濕模式的最低風速",
+              "send_off_before_on": "開機前傳送關機指令",
+              "custom_power_on": "自訂開機按鍵或場景（僅在標準開機失敗時使用）"
+            }
+          }
+        }
+      },
+      "remove_climate": {
+        "title": "移除冷氣",
+        "description": "選擇您想從網關中移除的冷氣。",
+        "data": {
+          "climate_id": "冷氣"
+        }
+      },
+      "add_generic": {
+        "title": "新增通用設備",
+        "description": "輸入資料以配對新通用設備。",
+        "data": {
+          "device_id": "設備 ID",
+          "infrared_id": "紅外線網關 ID",
+          "name": "設備名稱"
+        }
+      },
+      "add_sensor": {
+        "title": "新增溫濕度感測器",
+        "description": "輸入資料以配對新溫濕度感測器。",
+        "data": {
+          "device_id": "設備 ID",
+          "name": "設備名稱"
+        }
+      },
+      "hub_settings": {
+        "title": "網關設定",
+        "description": "修改存取憑證與網關選項。",
+        "data": {
+          "access_id": "涂鴉 Access ID",
+          "access_secret": "涂鴉 Access Secret",
+          "country": "涂鴉國家 API",
+          "enable_pulsar": "啟用涂鴉 Pulsar 串流",
+          "climate_update_interval": "冷氣更新間隔",
+          "sensor_update_interval": "溫濕度更新間隔"
+        }
+      },
+      "select_climate": {
+        "title": "選擇冷氣",
+        "description": "選擇您要管理的冷氣。",
+        "data": {
+          "climate_id": "冷氣"
+        }
+      },
+      "select_generic": {
+        "title": "選擇通用設備",
+        "description": "選擇您要管理的通用設備。",
+        "data": {
+          "generic_id": "通用設備"
+        }
+      },
+      "select_sensor": {
+        "title": "選擇溫濕度感測器",
+        "description": "選擇您要管理的溫濕度感測器。",
+        "data": {
+          "sensor_id": "溫濕度感測器"
+        }
+      }
+    },
+    "error": {
+      "cannot_change_access_id": "無法修改現有網關的 Access ID。",
+      "cannot_connect_to_tuya": "連線涂鴉伺服器失敗。請檢查您的網路。",
+      "device_already_configured": "此設備已設定。",
+      "device_already_configured_on_other_hub": "此設備已在其他網關上設定。",
+      "invalid_auth": "驗證失敗：無效的 Access ID 或 Access Secret。",
+      "invalid_data_center": "驗證失敗：無效的數據中心。",
+      "invalid_sensor_type": "所選設備不是有效的溫濕度感測器。",
+      "tuya_api_error": "涂鴉雲端錯誤：{error_info}"
+    },
+    "abort": {
+      "device_not_found": "找不到設備。"
+    }
+  },
+  "exceptions": {
+    "climate_error_turn_on": {
+      "message": "無法開機"
+    },
+    "climate_error_turn_off": {
+      "message": "無法關機"
+    },
+    "climate_error_temperature": {
+      "message": "無法變更溫度"
+    },
+    "climate_error_fan_mode": {
+      "message": "無法變更風速模式"
+    },
+    "climate_error_hvac_mode": {
+      "message": "無法變更空調模式"
+    },
+    "device_error_send_command": {
+      "message": "無法傳送指令"
+    }
+  }
+}

--- a/custom_components/tuya_smart_ir_ac/translations/zh-Hant.json
+++ b/custom_components/tuya_smart_ir_ac/translations/zh-Hant.json
@@ -48,7 +48,7 @@
       "options": {
         "climate": "冷氣機",
         "generic": "通用設備",
-        "sensor": "溫濕度感測器"
+        "sensor": "溫濕度感應器"
       }
     },
     "hvac_modes": {
@@ -86,9 +86,9 @@
     },
     "optional_entities": {
       "options": {
-        "current_temperature": "溫度感測器",
-        "current_humidity": "濕度感測器",
-        "hvac_mode": "空調控制",
+        "current_temperature": "溫度感應器",
+        "current_humidity": "濕度感應器",
+        "hvac_mode": "空調模式",
         "fan_mode": "風速控制",
         "temp_setpoint": "溫度控制"
       }
@@ -104,21 +104,21 @@
   "config": {
     "step": {
       "hub_settings": {
-        "title": "網關設定",
-        "description": "設定存取憑證與網關選項。",
+        "title": "控制器設定",
+        "description": "設定存取憑證與控制器選項。",
         "data": {
-          "access_id": "涂鴉 Access ID",
-          "access_secret": "涂鴉 Access Secret",
-          "country": "涂鴉國家 API",
-          "enable_pulsar": "啟用涂鴉 Pulsar 串流",
+          "access_id": "Tuya Access ID",
+          "access_secret": "Tuya Access Secret",
+          "country": "Tuya 國家 API",
+          "enable_pulsar": "啟用Tuya Pulsar 串流",
           "climate_update_interval": "冷氣更新間隔",
           "sensor_update_interval": "溫濕度更新間隔"
         }
       }
     },
     "error": {
-      "cannot_change_access_id": "無法修改現有網關的 Access ID。",
-      "cannot_connect_to_tuya": "連線涂鴉伺服器失敗。請檢查您的網路。",
+      "cannot_change_access_id": "無法修改現有控制器的 Access ID。",
+      "cannot_connect_to_tuya": "連線Tuya 伺服器失敗。請檢查您的網路。",
       "invalid_auth": "驗證失敗：無效的 Access ID 或 Access Secret。",
       "invalid_data_center": "驗證失敗：無效的數據中心。"
     }
@@ -126,11 +126,11 @@
   "options": {
     "step": {
       "init": {
-        "title": "涂鴉智慧紅外線設定",
+        "title": "Tuya 智慧紅外線設定",
         "menu_options": {
           "device_management": "設備管理",
           "presets_management": "全域預設管理",
-          "hub_settings": "網關設定"
+          "hub_settings": "控制器設定"
         }
       },
       "device_management": {
@@ -138,7 +138,7 @@
         "menu_options": {
           "climate_management": "冷氣管理",
           "generic_management": "通用設備管理",
-          "sensor_management": "溫濕度感測器管理",
+          "sensor_management": "溫濕度感應器管理",
           "back_to_init": "⬅️ 返回主選單"
         }
       },
@@ -178,10 +178,10 @@
         }
       },
       "sensor_management": {
-        "title": "溫濕度感測器管理",
+        "title": "溫濕度感應器管理",
         "menu_options": {
-          "add_sensor": "新增溫濕度感測器",
-          "remove_sensor": "移除現有溫濕度感測器",
+          "add_sensor": "新增溫濕度感應器",
+          "remove_sensor": "移除現有溫濕度感應器",
           "back_to_devices": "⬅️ 返回設備管理"
         }
       },
@@ -189,11 +189,11 @@
         "title": "新增冷氣",
         "description": "輸入資料以配對新冷氣。",
         "data": {
-          "infrared_id": "紅外線網關 ID",
+          "infrared_id": "紅外線控制器 ID",
           "device_id": "冷氣 ID",
           "name": "冷氣名稱",
-          "temperature_sensor": "溫度感測器",
-          "humidity_sensor": "濕度感測器",
+          "temperature_sensor": "溫度感應器",
+          "humidity_sensor": "濕度感應器",
           "min_temp": "最低溫度",
           "max_temp": "最高溫度",
           "temp_step": "溫度步進",
@@ -222,8 +222,8 @@
         "title": "編輯冷氣",
         "description": "更新冷氣的選項。",
         "data": {
-          "temperature_sensor": "溫度感測器",
-          "humidity_sensor": "濕度感測器",
+          "temperature_sensor": "溫度感應器",
+          "humidity_sensor": "濕度感應器",
           "min_temp": "最低溫度",
           "max_temp": "最高溫度",
           "temp_step": "溫度步進",
@@ -250,7 +250,7 @@
       },
       "remove_climate": {
         "title": "移除冷氣",
-        "description": "選擇您想從網關中移除的冷氣。",
+        "description": "選擇您想從控制器中移除的冷氣。",
         "data": {
           "climate_id": "冷氣"
         }
@@ -260,26 +260,26 @@
         "description": "輸入資料以配對新通用設備。",
         "data": {
           "device_id": "設備 ID",
-          "infrared_id": "紅外線網關 ID",
+          "infrared_id": "紅外線控制器 ID",
           "name": "設備名稱"
         }
       },
       "add_sensor": {
-        "title": "新增溫濕度感測器",
-        "description": "輸入資料以配對新溫濕度感測器。",
+        "title": "新增溫濕度感應器",
+        "description": "輸入資料以配對新溫濕度感應器。",
         "data": {
           "device_id": "設備 ID",
           "name": "設備名稱"
         }
       },
       "hub_settings": {
-        "title": "網關設定",
-        "description": "修改存取憑證與網關選項。",
+        "title": "控制器設定",
+        "description": "修改存取憑證與控制器選項。",
         "data": {
-          "access_id": "涂鴉 Access ID",
-          "access_secret": "涂鴉 Access Secret",
-          "country": "涂鴉國家 API",
-          "enable_pulsar": "啟用涂鴉 Pulsar 串流",
+          "access_id": "Tuya Access ID",
+          "access_secret": "Tuya Access Secret",
+          "country": "Tuya API 區域",
+          "enable_pulsar": "啟用 Tuya Pulsar 串流",
           "climate_update_interval": "冷氣更新間隔",
           "sensor_update_interval": "溫濕度更新間隔"
         }
@@ -299,22 +299,22 @@
         }
       },
       "select_sensor": {
-        "title": "選擇溫濕度感測器",
-        "description": "選擇您要管理的溫濕度感測器。",
+        "title": "選擇溫濕度感應器",
+        "description": "選擇您要管理的溫濕度感應器。",
         "data": {
-          "sensor_id": "溫濕度感測器"
+          "sensor_id": "溫濕度感應器"
         }
       }
     },
     "error": {
-      "cannot_change_access_id": "無法修改現有網關的 Access ID。",
-      "cannot_connect_to_tuya": "連線涂鴉伺服器失敗。請檢查您的網路。",
+      "cannot_change_access_id": "無法修改現有控制器的 Access ID。",
+      "cannot_connect_to_tuya": "連線 Tuya 伺服器失敗。請檢查您的網路。",
       "device_already_configured": "此設備已設定。",
-      "device_already_configured_on_other_hub": "此設備已在其他網關上設定。",
+      "device_already_configured_on_other_hub": "此設備已在其他控制器上設定。",
       "invalid_auth": "驗證失敗：無效的 Access ID 或 Access Secret。",
       "invalid_data_center": "驗證失敗：無效的數據中心。",
-      "invalid_sensor_type": "所選設備不是有效的溫濕度感測器。",
-      "tuya_api_error": "涂鴉雲端錯誤：{error_info}"
+      "invalid_sensor_type": "所選設備不是有效的溫濕度感應器。",
+      "tuya_api_error": "Tuya 雲端錯誤：{error_info}"
     },
     "abort": {
       "device_not_found": "找不到設備。"


### PR DESCRIPTION
In PR #142, I implemented a "power-off before power-on" compatibility option. However, it behaves strangely with the `turn_on_with*()` functions. There might be some additional checks on Tuya's end.

In this PR, I removed that workaround and only kept the scene-based approach. With this approach, users can set up button routines in the Smart Life app and use the corresponding scene as the power-on action.

A zh-Hant translation file is also included in this PR.

Any feedback would be appreciated, and please feel free to merge it if everything looks good. : )