### PR TITLE
Retain Pulsar reconnect task and harden message dispatch

### DIFF
--- a/custom_components/tuya_smart_ir_ac/bridge.py
+++ b/custom_components/tuya_smart_ir_ac/bridge.py
@@ -1,5 +1,6 @@
 import logging
 import json
+from collections.abc import Awaitable, Callable
 from homeassistant.core import HomeAssistant
 
 from .tuya_connector import TuyaOpenPulsar
@@ -13,22 +14,25 @@ class TuyaPulsarBridge:
         """Initialize the Pulsar bridge."""
         self.hass = hass
         self._client = client
-        self._handlers = {}
+        self._handlers: dict[str, list[Callable[[str, dict], Awaitable[None]]]] = {}
         self._client.add_message_listener(self._on_message)
 
-    def register_handler(self, dev_id: str, callback: Callable) -> None:
+    def register_handler(
+        self, dev_id: str, callback: Callable[[str, dict], Awaitable[None]]
+    ) -> None:
         """Register a callback handler for a specific device."""
-        self._handlers[dev_id] = callback
+        self._handlers.setdefault(dev_id, []).append(callback)
 
     async def _on_message(self, decrypt_data: str) -> None:
         """Handle incoming Pulsar messages and dispatch to handlers safely."""
         try:
             data = json.loads(decrypt_data)
             dev_id = data.get("devId")
-            handler = self._handlers.get(dev_id)
-            
-            if handler:
-                self.hass.add_job(handler, dev_id, data)
-                
+            handlers = self._handlers.get(dev_id)
+
+            if handlers:
+                for handler in handlers:
+                    self.hass.async_create_task(handler(dev_id, data))
+
         except Exception as e:
             _LOGGER.error("Error processing Pulsar message: %s", e)

--- a/custom_components/tuya_smart_ir_ac/tuya_connector/openpulsar.py
+++ b/custom_components/tuya_smart_ir_ac/tuya_connector/openpulsar.py
@@ -44,6 +44,7 @@ class TuyaOpenPulsar:
         
         self._stop_event = asyncio.Event()
         self._listeners: Set[Callable[[str], Awaitable[None]]] = set()
+        self._task: Optional[asyncio.Task] = None
         
         # Pre-calculate cryptographic assets
         self._access_secret_bytes = access_secret.encode('utf-8')
@@ -83,11 +84,14 @@ class TuyaOpenPulsar:
     async def start(self):
         """Start the asynchronous connection loop."""
         self._stop_event.clear()
-        asyncio.create_task(self._connect_loop())
+        self._task = asyncio.create_task(self._connect_loop())
 
     async def stop(self):
         """Stop the client and close session only if owned."""
         self._stop_event.set()
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            self._task = None
         self._listeners.clear()
         if self._owns_session and self._session and not self._session.closed:
             await self._session.close()


### PR DESCRIPTION
The reconnect loop was a bare `asyncio.create_task(...)` with the handle thrown away, so the GC could quietly kill it and silently stop real-time updates. Now we hold the reference and cancel it on stop instead.