### PR TITLE
Enable Pulsar TLS verification and verify v2 message signatures

### DIFF
--- a/custom_components/tuya_smart_ir_ac/tuya_connector/openpulsar.py
+++ b/custom_components/tuya_smart_ir_ac/tuya_connector/openpulsar.py
@@ -5,6 +5,7 @@ import aiohttp
 import base64
 import hashlib
 import json
+import ssl
 from typing import Callable, Awaitable, Set, Tuple, Optional
 from Crypto.Cipher import AES
 
@@ -41,6 +42,9 @@ class TuyaOpenPulsar:
 
         # Track the live connection state of the WebSocket
         self._is_connected = False
+
+        # SSL context for TLS certificate verification (created once)
+        self._ssl_context = ssl.create_default_context()
         
         self._stop_event = asyncio.Event()
         self._listeners: Set[Callable[[str], Awaitable[None]]] = set()
@@ -112,7 +116,7 @@ class TuyaOpenPulsar:
                     self._topic_url, 
                     headers=headers,
                     heartbeat=PING_INTERVAL_SECONDS,
-                    ssl=False
+                    ssl=self._ssl_context
                 ) as ws:
                     logger.info("Successfully connected to Tuya WebSocket.")
                     reconnect_delay = 1
@@ -163,7 +167,18 @@ class TuyaOpenPulsar:
             pv = data_map.get("pv")
             raw_data_str = data_map.get("data", "")
             raw_encrypted_bytes = base64.b64decode(raw_data_str)
-            
+
+            # Verify v2 envelope signature when present (conservative: only
+            # enforce if a sign field exists, to avoid breaking v1/legacy).
+            if encrypt_version == "v2" and data_map.get("sign") is not None:
+                if not self._verify_v2_sign(
+                    raw_data_str, data_map.get("t"), data_map.get("sign")
+                ):
+                    logger.warning(
+                        "Dropping v2 message with invalid signature."
+                    )
+                    return
+
             # Deterministic routing based on protocol metadata
             if encrypt_version == "v2" and pv == "2.0":
                 #logger.debug("Processing message format: AES-GCM (encryptVersion: v2, pv: 2.0)")


### PR DESCRIPTION
Two small hardening changes in `openpulsar.py`:

- The WebSocket connected with `ssl=False` (no cert validation) → now uses a real default SSL context.
- `_verify_v2_sign()` existed but was never called → now we verify v2 message signatures and drop ones that fail.

We only enforce the signature check when a `sign` field is actually
present, so legacy/v1 messages are unaffected.
