### PR TITLE
fix: add future annotations to prevent NameError on Python 3.13

### DIFF
--- a/custom_components/tuya_smart_ir_ac/models.py
+++ b/custom_components/tuya_smart_ir_ac/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import (
     dataclass,
     field,


### PR DESCRIPTION
### Description
This PR fixes an issue introduced in newer versions of Home Assistant running Python 3.13+, where the integration fails to load entirely due to a circular dependency / forward reference error during the import execution phase.

### Problem
When Home Assistant attempts to set up the component, it triggers a `NameError` in `models.py`:
`NameError: name 'TuyaClimateCoordinator' is not defined.`
This happens because `TuyaClimateCoordinator` is referenced inside `models.py` before the type annotations can be resolved by the Python 3.13 strict validator.

### Solution
Added `from __future__ import annotations` to the very first line of `models.py` to postpone evaluation of type hints. This gracefully breaks the circular import sequence and allows the custom component to load correctly.

Tested on Home Assistant 2026.x running Python 3.13.